### PR TITLE
Add reference data for dependency cross-validation

### DIFF
--- a/reference-data/.gitignore
+++ b/reference-data/.gitignore
@@ -1,0 +1,6 @@
+# Large binary files -- download separately per SUMMARY.md instructions
+*.mdb
+*.zip
+*.xlsx
+*.docx
+*.html

--- a/reference-data/dol-careeronestop/SUMMARY.md
+++ b/reference-data/dol-careeronestop/SUMMARY.md
@@ -1,0 +1,183 @@
+# DOL CareerOneStop Occupational License Finder — Summary
+
+## Source
+- **Main page**: https://www.careeronestop.org/toolkit/training/find-licenses.aspx
+- **Data download page**: https://www.careeronestop.org/Developers/Data/occupational-licenses.aspx
+- **Bulk data host**: https://data.widcenter.org/wfinfodb/License/
+- **API explorer**: https://api.careeronestop.org/api-explorer/
+- **Publisher**: U.S. Department of Labor (DOL), via CareerOneStop / Analyst Resource Center (ARC)
+- **Last crawled**: April 2026
+
+## Files Downloaded
+
+| File | Description | Size |
+|------|-------------|------|
+| `COSFlatExport.zip` | Full flat-export of all license records (Microsoft Access .mdb) | 7.8 MB zip / 138 MB uncompressed |
+| `cos-flat-export/COSFlatExport.mdb` | Extracted Microsoft Access database — all license records | 138 MB |
+| `LicensedOccupations_DataDownloadReadme.docx` | Official technical readme / data dictionary | 19 KB |
+| `ARC_Licenses_Review_and_Processing.docx` | ARC internal review and processing documentation | 21 KB |
+| `license-download-index.html` | Directory listing of all available download files on ARC server | 37 KB |
+| `careeronestop-occupational-licenses-page.html` | CareerOneStop data download landing page | 30 KB |
+| `api-license-finder-docs.html` | API Explorer docs for the License Finder API endpoints | 42 KB |
+
+## Data Source Overview
+
+License information is collected from each U.S. state by the **Analyst Resource Center (ARC)**, an arm of the Department of Labor / Employment and Training Administration. Key facts:
+- States submit revisions **every two years** (cadence)
+- CareerOneStop updates the public dataset **every 4–6 months** as new state data arrives
+- **Not all states submit** license information; coverage is therefore incomplete for some states/professions
+- Most recent dataset update in the flat export: **October 2024** (COSFlatExport.zip dated 2024-10-14)
+
+## Bulk Download Options
+
+### Primary: COSFlatExport.zip (recommended for analysis)
+- URL: `https://data.widcenter.org/wfinfodb/License/COSFlatExport.zip`
+- Contents: Single Microsoft Access .mdb file (`COSFlatExport.mdb`), 138 MB uncompressed
+- Format: Microsoft Access database (requires Access, mdbtools, or similar to read)
+- Coverage: All states, all license types — flat (one row per license record)
+
+### Per-state files (also available on the ARC server)
+The directory listing (`license-download-index.html`) shows state-by-state files named:
+`WID28LicenseST{XX}Export{YYMM}.mdb[.zip]`
+where `XX` is a state code (01–53), and `YYMM` is the export year/month.
+- States with 2024 exports: ST02, ST05, ST06, ST08–ST11, ST13, ST17, ST19–ST22, ST28–ST29, ST31, ST33, ST35, ST37, ST39–ST41, ST44–ST45, ST47, ST48, ST49, ST53 (and more)
+- Older states at 2023 or earlier vintages also available
+
+### Additional reference files on the ARC server:
+- `Occupational Licenses History.pptx` (546 KB, dated 2025-06-03)
+- `Occupational Licensure Coverage and Climate - Copy.pptx` (857 KB, dated 2025-06-03)
+- `Occupational Licensure in the States-Final.pdf` (734 KB, dated 2023-09-28)
+
+## Data Schema — Fields Per License Record
+
+From the readme and API response structure, each license record includes:
+
+### Core identification fields:
+| Field | Description |
+|-------|-------------|
+| `ID` | Unique license record identifier |
+| `Title` | License title (e.g., "Registered Nurse") |
+| `Description` | Full text description of the license |
+| `State` | State abbreviation (e.g., "IL", "CA") |
+
+### Status/classification fields:
+| Field | Description |
+|-------|-------------|
+| `ActiveStatusDesc` | Whether the license is currently active |
+| `CertificationIndDesc` | Whether a certification is required |
+| `ContinuingEDUIndDesc` | Whether continuing education is required |
+| `CriminalIndDesc` | Whether criminal background check is required |
+| `EducationIndDesc` | Whether education requirement exists |
+| `LicExamIndDesc` | Whether a licensing exam is required |
+| `ExperienceIndDesc` | Whether experience requirement exists |
+| `VeteransIndDesc` | Whether veterans-specific provisions apply |
+
+### Occupation linkage:
+| Field | Description |
+|-------|-------------|
+| O*NET code(s) | Linked O*NET-SOC occupation codes |
+
+### Issuing agency fields:
+| Field | Description |
+|-------|-------------|
+| `Agency` (issuing org) | Name of the state agency that issues the license |
+| `Phone` | Agency contact phone |
+| `Email` | Agency contact email |
+| `Url` | Agency website URL |
+
+## API Access
+
+### Base URL: `https://api.careeronestop.org/v1/`
+
+### Authentication:
+- Requires **API Token** (registration at CareerOneStop developer portal)
+- Requires **userId** parameter with every request
+
+### License Endpoints:
+
+#### List Licenses
+```
+GET /v1/license/{userId}/{keyword}/{location}/{sortColumns}/{sortDirections}/{startRecord}/{limitRecord}
+```
+Parameters:
+- `keyword`: profession keyword or O*NET code (e.g., "nurse" or "29-1171.00"); use `0` for no filter
+- `location`: state abbreviation (e.g., "IL"), "US" for all states, or `0` for all states
+- `sortColumns`: "Title", "Agency", or "State" (or `0` for relevance)
+- `sortDirections`: "ASC" or "DESC" (or `0` for relevance)
+- `startRecord`: integer, pagination offset
+- `limitRecord`: integer, page size
+
+#### Get License Details by ID
+```
+GET /v1/license/{userId}/{licenseId}
+```
+
+### Full JSON Response Schema:
+```json
+{
+  "LicenseList": [
+    {
+      "ID": "string",
+      "Title": "string",
+      "Description": "string",
+      "State": "string",
+      "ActiveStatusDesc": "string",
+      "CertificationIndDesc": "string",
+      "ContinuingEDUIndDesc": "string",
+      "CriminalIndDesc": "string",
+      "EducationIndDesc": "string",
+      "LicExamIndDesc": "string",
+      "ExperienceIndDesc": "string",
+      "VeteransIndDesc": "string",
+      "Agency": {
+        "Name": "string",
+        "Phone": "string",
+        "Email": "string",
+        "Url": "string"
+      }
+    }
+  ],
+  "LicenseDetail": { "...same fields..." },
+  "RecordCount": 1,
+  "DidYouMean": "string",
+  "AutoCorrection": "string",
+  "QueriedOn": {
+    "Code": "string",
+    "Title": "string",
+    "Type": "string",
+    "IsKeywordSearch": true
+  }
+}
+```
+
+## Additional API Domains Available (Context)
+
+The CareerOneStop API also exposes (beyond licenses):
+- American Job Centers (by location / by ID)
+- Apprenticeships
+- Certifications
+- Employment Patterns
+- Jobs V2 (list/detail)
+- Labor Market Information (LMI by O*NET)
+- Locations (validation)
+- Occupations (by keyword / by skills)
+- Professional Associations
+- ReEntry Programs
+- Salaries (compare by location / by occupation)
+- Skills Gaps / Skills Matcher
+- Training Programs
+- Unemployment rates / UI websites
+
+## Usefulness for Step Dependencies
+
+This database is the federal government's canonical source for **Step 9** of the SBA guide (Apply for Licenses and Permits). It maps:
+- Which licenses exist in which states (jurisdiction-level coverage)
+- What requirements attach to each license (education, exams, experience, criminal check, continuing ed)
+- Which O*NET occupation codes each license relates to (linking licenses to job roles)
+
+The indicator fields (`EducationIndDesc`, `LicExamIndDesc`, `ExperienceIndDesc`, `ContinuingEDUIndDesc`) provide boolean-style flags for requirement categories — useful for building dependency trees (e.g., "this license requires an exam, which requires certain education prerequisites").
+
+**Limitations for prerequisite analysis:**
+- Fields are indicator flags (yes/no), not structured prerequisite sequences
+- The database does not capture *ordering* within licensing requirements (e.g., whether the exam must precede the application)
+- The Knee Center KRRC database (see reference-data/knee-center/) provides more quantitative and structured requirement data (hours, fees, degree level) that complements this dataset

--- a/reference-data/knee-center/SUMMARY.md
+++ b/reference-data/knee-center/SUMMARY.md
@@ -1,0 +1,153 @@
+# WVU Knee Regulatory Research Center (KRRC) Occupational Licensing Dataset — Summary
+
+## Source
+- **Institution**: Knee Regulatory Research Center, West Virginia University (WVU)
+- **Primary URL**: https://knee.wvu.edu/data
+- **2025 release page**: https://knee.wvu.edu/publications/knee-center-research/2025/12/19/annual-licensing-database-snapshot-2025
+- **2024 release (CSOR mirror)**: https://csorwvu.com/annual-licensing-database-snapshot-2024-4424/
+- **Older OLLRP data**: https://knee.wvu.edu/data/ollrp-database
+- **Last crawled**: April 2026
+
+## Files Downloaded
+
+| File | Description | Size |
+|------|-------------|------|
+| `data-2025-release.xlsx` | **Primary file**: 2025 annual snapshot, 96 professions × 51 jurisdictions | 857 KB |
+| `KRRCDatabase2024.xlsx` | 2024 annual snapshot (earlier vintage, 77 professions updated + 27 new = 77 total at that point) | 556 KB |
+| `Database_Update2024.xlsx` | 2024 updated professions only | 497 KB |
+| `Database_New2024.xlsx` | 2024 newly added professions only | 232 KB |
+| `krrc_data_dictionary.docx` | Official data dictionary for all data files | 31 KB |
+| `2025-profession-update-notes.docx` | 2025 release update notes (tracks changes per profession) | 24 KB |
+| `knee-center-2025-page.html` | 2025 release web page | 59 KB |
+
+## Dataset Coverage
+
+### 2025 Release (primary — `data-2025-release.xlsx`)
+- **96 professions** across **51 jurisdictions** (50 states + District of Columbia)
+- Updated 77 professions from 2024 database; added 19 new professions
+- Data collected January–December 2025 from state government sources only
+
+### 2024 Release (`KRRCDatabase2024.xlsx`)
+- 77 professions (50 from 2023 database updated; 27 new professions added)
+- Data collected May 2023–December 2024
+
+## Workbook Structure (2025 XLSX)
+
+The 2025 XLSX contains **97 sheets**:
+1. `All Professions` — consolidated data for all 96 professions (primary analysis sheet)
+2. One sheet per profession (96 sheets), named by profession title
+
+### Full list of 96 professions (sheets 2–97):
+Acupuncturist, Auctioneer, Auctioneer Apprentice, Audiologist, Barber, Certified Nurse Midwife, Certified Public Accountant, Chiropractor, Chiropractor Assistant, Clinical Nurse Specialist, Cosmetologist, Crane Operator, Dental Assistant, Dental Hygienist, Dental Therapist, Dentist, Denturist, Dialysis Technician, Esthetician, Interior Designer, Lactation Consultant, Licensed Practical Nurse, Massage Therapist, Nail Technician, Natural Hair Braider, Nuclear Medicine Technologist, Nurse Anesthetist, Nurse Practitioner, Occupational Therapist, Occupational Therapist Assistant, Ocularist, Optician, Optometrist, Pharmacist, Pharmacy Technician, Physical Therapist, Physical Therapist Assistant, Physician, Physician Assistant, Podiatrist, Radiologic Technologist, Radiologic Assistant, Registered Nurse, Shampoo Assistant, Speech Language Pathologist, Speech Language Pathologist Assistant, Surgeon, Tattoo Artist, Veterinarian, Veterinarian Technician, Architect, Dietetic Technician, Embalmer, Engineer Intern, Forester, Forester Technician, Funeral Director, Funeral Service Assistant, Funeral Service Trainee, Funeral Supervisor, Geoscientist in Training, Home Inspector, Home Inspector Trainee, Land Surveyor in Training, Landscape Architect, Medical Health Physicist Assistant, Mortician, Pedorthist, Private Investigator, Professional Engineer, Professional Geophysicist, Professional Geoscientist, Professional Land Surveyor, Respiratory Therapist, Soil Scientist, Soil Classifier, Surgical Assistant, Certified Engineer Geologist, Certified Hydrologist, Dental Radiographer, Diagnostic Medical Sonographer, Landscape Architect Trainee, Limited X-ray Machine Operators, Orthotic Assistant, Orthotic Fitter, Orthotic Fitter Assistant, Orthotic Technician, Orthotist, Peace Officer, Police Officer, Prosthetic Assistant, Prosthetic Technician, Prosthetist, Prosthetist-Orthotist, Psychologist, Structural Engineer
+
+## Column Schema (from shared strings inspection)
+
+### Row identifiers:
+| Column | Description |
+|--------|-------------|
+| `State` | State name (e.g., "Alabama") |
+| `Statefips` | FIPS code for state |
+| `Year` | Data year |
+| `Profession` | Profession name |
+| `Profession Code` | Internal KRRC profession code |
+| `SOC` | Bureau of Labor Statistics Standard Occupational Classification code |
+| `Industry` | Industry category (e.g., "Healthcare", "Engineering", "Sales") |
+
+### Licensing requirement fields:
+| Column | Description |
+|--------|-------------|
+| `Type of Regulation` | License / Registration / Certification / Certificate / Voluntary Certification / Unique License |
+| `Type of Regulation Notes` | Notes on the regulation type |
+| `Initial Licensing Fee` (also `Initial_Fee`) | Fee to obtain initial license (dollars) |
+| `Renewal_Fee` | Fee to renew license, prorated to biennial cycle |
+| `Degree` | Minimum education degree required (e.g., "High School Diploma", "Associate's Degree", "Bachelor's Degree", "Master's Degree", "Doctorate Degree") |
+| `Education Code` | Coded version of the education requirement |
+| `Continuing_Education` | Continuing education hours required per renewal cycle (prorated to biennial) |
+| `Citizenship` | Whether citizenship is required |
+| `Minimum Age` | Minimum age requirement |
+| `Good Moral Character` | Whether good moral character requirement exists |
+| `English_Language` | Whether English language requirement exists |
+| `Exams` | Number or type of exams required |
+| `Experience` | Experience hours/years required |
+| `Experience Or Training` | Alternative field for experience or training |
+| `Number of Exams` | Count of required exams |
+| `Credit To Sit for Exam` | Whether educational credit required to sit for exam |
+| `Reciprocity or Endorsement` | Whether reciprocity/endorsement with other states is available |
+| `Multiple Pathways` | Whether multiple education/experience path combinations exist |
+| `Regulation` | Citation or description of the authorizing regulation |
+
+### Values used for Degree field (ordered, from lowest to highest):
+1. 7th Grade
+2. 8th Grade
+3. 9th Grade
+4. 10th Grade
+5. High School / High School Diploma / High School degree
+6. Some College / One year of college / Three Years of College
+7. Associate's Degree / Associates Degree
+8. Bachelor's Degree / Bachelors Degree
+9. Master's Degree
+10. Doctorate Degree
+
+### Values used for Type of Regulation:
+- License (most restrictive — title and practice protected)
+- Registration
+- Certification
+- Certificate
+- Voluntary Certification (weakest — optional)
+- Unique License
+- Apprenticeship (for trainee/intern roles)
+
+### Values for Reciprocity or Endorsement:
+- Yes
+- No
+- Endorsement
+- Reciprocity
+- Reciprocity/Endorsement
+- Comity
+- Equivalency
+
+## Methodology Notes
+
+- **Data sources**: State government sources only (statutes, administrative codes, agency communications, licensing board websites). Industry groups explicitly excluded as "frequently out of date."
+- **When data not publicly available**: Researchers contacted licensing boards directly by email or phone.
+- **Standardization approach**:
+  - Education/training hours converted to a common scale using standard full-time working hours definitions
+  - Renewal fees and continuing education hours **prorated to a biennial (2-year) period** for cross-state comparability
+  - Multiple pathways: when multiple education/experience combinations qualify, the "most common or reasonable" path is listed; the `Multiple Pathways` flag indicates alternatives exist
+- **Versioning**: Database may be adjusted for errors. All changes tracked in the Universal Read.Me and Update Notes documents.
+
+## Suggested Citation
+Norris, Conor, Kelley, Ethan, and Carneal, Troy. (2025). "KRRC Annual Licensing Database Snapshot: 2025." Knee Regulatory Research Center, West Virginia University.
+
+## Related Dataset: OLLRP (Historical Data)
+The Knee Center also hosts the Occupational Licensing Law Research Project (OLLRP) database covering ~300 occupations across all 50 states + DC from **1870 to 2019** (historical panel data). This is different from the annual snapshots — it is cross-sectional/longitudinal, authored by Morris Kleiner, Jason Hicks, et al. Data and Stata code available at: https://knee.wvu.edu/data/ollrp-database
+
+## Usefulness for Step Dependencies
+
+This dataset is directly useful for analyzing **licensing requirements as structured prerequisites**:
+
+1. **Degree field** defines the minimum educational attainment required before applying — a hard prerequisite step (complete education before applying for license).
+
+2. **Exams / Credit To Sit for Exam** — indicates whether you must complete certain education *before* being eligible to take the licensing exam. This creates a dependency: Education → Exam → License Application.
+
+3. **Experience** field — hours of supervised experience required, which often must be completed under a provisional or trainee license (also captured as a separate profession, e.g., "Auctioneer Apprentice", "Engineer Intern", "Home Inspector Trainee", "Land Surveyor in Training", "Landscape Architect Trainee").
+
+4. **Trainee/intern professions** — The dataset explicitly tracks junior/trainee license categories for many professions. This means the dataset encodes a two-step licensing sequence: Trainee License → Full License, with the trainee license having its own requirements.
+
+5. **Multiple Pathways** — flags when alternative prerequisite paths exist (e.g., more education = less required experience, or apprenticeship as an alternative).
+
+6. **Type of Regulation** hierarchy — License > Certification > Registration > Voluntary Certification implies a gradient of regulatory stringency. A state may require one tier before granting another.
+
+7. **State-level variation** — since requirements vary by jurisdiction (51 jurisdictions), the dataset enables mapping which states impose additional prerequisites not required elsewhere.
+
+### Dependency pattern visible in the data:
+Many professions appear in pairs/groups that encode a prerequisite chain:
+- Chiropractor Assistant → Chiropractor
+- Auctioneer Apprentice → Auctioneer
+- Engineer Intern → Professional Engineer
+- Home Inspector Trainee → Home Inspector
+- Land Surveyor in Training → Professional Land Surveyor
+- Funeral Service Trainee → Funeral Service Assistant → Funeral Director
+- Orthotic/Prosthetic Assistant → Technician → full Orthotist/Prosthetist
+
+These hierarchical profession pairs are explicit, structured prerequisite sequences captured within the dataset itself.

--- a/reference-data/maryland-plc/SUMMARY.md
+++ b/reference-data/maryland-plc/SUMMARY.md
@@ -1,0 +1,158 @@
+# Maryland PLC Data Catalog - Summary
+
+## Source
+
+- **Dataset**: PLC Data Catalog
+- **Publisher**: Maryland Open Data Portal (opendata.maryland.gov)
+- **Catalog page**: https://opendata.maryland.gov/d/gdzy-2fen
+- **Data.gov entry**: https://catalog.data.gov/dataset/plc-data-catalog
+- **Download URL**: https://opendata.maryland.gov/api/views/gdzy-2fen/rows.csv?accessType=DOWNLOAD
+- **Local file**: `plc-data-catalog.csv` (1.9 MB)
+- **Legal basis**: Maryland Transparent Government Act of 2024
+- **Data published**: January 15, 2026; last modified January 16, 2026
+- **Fiscal year represented**: 2026 (all 1,058 rows)
+
+## Dataset Dimensions
+
+| Metric | Value |
+|--------|-------|
+| Total rows (PLC types) | 1,058 |
+| Total columns | 28 |
+| File size | 1.9 MB |
+
+## Columns (28 total)
+
+| # | Column Name | Notes |
+|---|-------------|-------|
+| 1 | PLC Title | Name of the permit, license, or certificate |
+| 2 | PLC Description | Free-text description |
+| 3 | Duration Length | Numeric part of validity period |
+| 4 | Legal Authority | Statute / COMAR citation |
+| 5 | Application Method | How applications are submitted |
+| 6 | IT System(s) | Software/system used to administer |
+| 7 | Manual Tasks | Human-step description |
+| 8 | Current Processing Timeline (Days) | Days to final decision |
+| 9 | Application Fees | Dollar amount (numeric) |
+| 10 | Revenue Allocation | Where fees go |
+| 11 | Recommended Changes | Suggested statutory or resource changes |
+| 12 | Is Timeline Met? | Boolean: true/false |
+| 13 | Duration Type | Years / Months / Days / Indefinite / Variable |
+| 14 | Submission Date/Time | When record was submitted |
+| 15 | Fiscal Year | Reporting year (all = 2026) |
+| 16 | Factors Impeding Timely Processing | Bottleneck description |
+| 17 | Application Process | Narrative process description |
+| 18 | Last Modified | Record modification timestamp |
+| 19 | Applications | Volume of applications |
+| 20 | Issuances | Volume of issuances |
+| 21 | Review Complexity Check | Boolean / free-text on field-agent requirement |
+| 22 | Review Complexity | Detailed description of review process |
+| 23 | Department | Issuing department |
+| 24 | Agency | Sub-agency within department |
+| 25 | Department Abbrevation | Abbreviation (sic) |
+| 26 | Criminal History | Criminal background check requirements |
+| 27 | Significant Prior Updates | History of changes |
+| 28 | Duration Explaination | Explanation of validity period (sic) |
+
+## Key Statistics
+
+### Issuing Departments (top 10)
+
+| Department | PLC Count |
+|------------|-----------|
+| Department of Health | 374 |
+| Department of Labor | 168 |
+| Department of Natural Resources | 126 |
+| Department of the Environment | 112 |
+| Alcohol Tobacco and Cannabis Commission | 70 |
+| Maryland Insurance Administration | 43 |
+| State Lottery and Gaming Control Agency | 36 |
+| Public Service Commission | 30 |
+| Department of State Police | 20 |
+| Maryland Cannabis Administration | 15 |
+
+### Duration Types
+
+| Type | Count |
+|------|-------|
+| Years | 759 |
+| Indefinite | 164 |
+| Variable | 101 |
+| Days | 21 |
+| Months | 13 |
+
+### Application Fees
+
+| Metric | Value |
+|--------|-------|
+| Rows with numeric fee | 1,058 (100%) |
+| No-fee PLCs ($0) | 293 (27.7%) |
+| PLCs with fees | 765 (72.3%) |
+| Minimum fee | $0 |
+| Maximum fee | $2,000,000 |
+| Average processing timeline | 60.9 days |
+| Minimum processing timeline | 0 days |
+| Maximum processing timeline | 1,080 days |
+
+### Timeline Compliance
+
+| Status | Count | Pct |
+|--------|-------|-----|
+| Timeline NOT met (`false`) | 955 | 90.3% |
+| Timeline met (`true`) | 103 | 9.7% |
+
+Note: 90.3% of PLC types report that their stated processing timeline is not being met — a key finding indicating systemic backlog across Maryland agencies.
+
+### Application Methods (top 5)
+
+| Method | Count |
+|--------|-------|
+| Online (Web or Mobile) | 316 |
+| Mail | 117 |
+| Online + In Person | 90 |
+| Online + Mail | 88 |
+| Online + Mail + In Person | 61 |
+
+### IT Systems (top 5 distinct entries)
+
+| System | Count |
+|--------|-------|
+| MD Outdoors (web portal) | 88 |
+| OneStop and Salesforce | 69 |
+| Smartsheet | 64 |
+| MyLicensing Office (MLO) | 61 |
+| BPQA (in-house proprietary) | 58 |
+
+There are 207 distinct IT system descriptions, reflecting significant fragmentation across agencies.
+
+## Sample Records
+
+**Record 1**: Charity deer processing plant
+- Department: Department of Health / Public Health Administration
+- Fee: $0, Duration: 1 Year, Timeline: 30 days (NOT met)
+
+**Record 2**: Center for recreation and community
+- Department: Department of Health / Public Health Administration
+- Fee: $50, Duration: 1 Year, Timeline: 30 days (NOT met), IT: Salesforce
+
+**Record 3**: Emergency Medical Responder
+- Department: Maryland Institute for Emergency Medical Services Systems
+- Fee: $0, Duration: 3 Years, Timeline: 5 days (NOT met), IT: Image Trend
+
+## Relevance for Dependency Enrichment
+
+This dataset is valuable for enriching permit dependency relationships because:
+
+1. **Agency identification**: The `Department` and `Agency` columns let you map PLC types to the exact administering body, enabling cross-agency dependency detection.
+2. **Processing timelines**: `Current Processing Timeline (Days)` provides realistic wait-time estimates for critical-path analysis in multi-permit workflows.
+3. **Fee data**: `Application Fees` enables cost modeling for permit stacks.
+4. **IT systems**: The `IT System(s)` column reveals which systems share infrastructure, hinting at bundling or cross-agency coordination opportunities.
+5. **Modernization signals**: `Is Timeline Met?` (90% false) and `Recommended Changes` expose which PLCs are bottlenecks — useful for flagging high-risk dependencies.
+6. **Legal authority**: `Legal Authority` links each PLC to its COMAR / statutory citation, enabling authoritative prerequisite chain validation.
+7. **Duration types**: Validity period data helps model renewal cascades in dependent permit stacks.
+
+## Files in This Directory
+
+| File | Description |
+|------|-------------|
+| `plc-data-catalog.csv` | Full dataset, 1,058 rows, 28 columns, 1.9 MB |
+| `SUMMARY.md` | This file |

--- a/reference-data/maryland-plc/plc-data-catalog.csv
+++ b/reference-data/maryland-plc/plc-data-catalog.csv
@@ -1,0 +1,1 @@
+/home/vercel-sandbox/workspace/plj-repo/reference-data/maryland-plc/plc-data-catalog.csv

--- a/reference-data/nj-navigator/SUMMARY.md
+++ b/reference-data/nj-navigator/SUMMARY.md
@@ -1,0 +1,305 @@
+# NJ Navigator Reference Data — Summary
+
+Source repo: https://github.com/newjersey/navigator.business.nj.gov (branch: main)
+Downloaded: 2026-04-20
+
+---
+
+## What This Is
+
+NJ Navigator (business.nj.gov) is New Jersey's one-stop dashboard for starting and managing a
+business. The application presents each user with a personalized **Roadmap** — an ordered checklist
+of tasks grouped into Steps — based on their industry and business persona.
+
+---
+
+## Repository Layout (relevant to data structure)
+
+```
+content/src/roadmaps/          <- all task/roadmap DATA lives here
+  steps.json                   <- ordered Step definitions (standard roadmap)
+  steps-foreign.json           <- steps for foreign (out-of-state) entities
+  steps-domestic-employer.json <- steps for domestic employer persona
+  task-dependencies.json       <- THE DEPENDENCY GRAPH (see below)
+  nonEssentialQuestions.json   <- optional add-on questions and their associated tasks
+  tasks/                       <- ~119 Markdown files, one per task
+  license-tasks/               <- license-specific task Markdown files
+  municipal-tasks/             <- municipality-specific task Markdown files
+  env-tasks/                   <- environmental task Markdown files
+  raffle-bingo-steps/          <- raffle/bingo industry tasks
+  industries/                  <- ~65 JSON files, one per industry roadmap
+  add-ons/                     <- ~93 JSON files, modular task add-ons
+
+shared/src/
+  industry.ts                  <- Industry and AddOn TypeScript interfaces
+  types/types.ts               <- Task, Roadmap, Step, TaskDependencies, TaskLink interfaces
+  static/loadTasks.ts          <- server-side task loading + dependency resolution logic
+
+web/src/lib/roadmap/
+  roadmapBuilder.ts            <- client-side roadmap assembly (steps + tasks + add-ons)
+web/src/lib/async-content-fetchers/
+  fetchTaskByFilename.ts       <- resolves task + its unlockedBy links at runtime
+```
+
+---
+
+## The Dependency / Ordering Model
+
+### Layer 1 — Steps (phase ordering)
+
+`steps.json` defines the top-level phases. Each Step has a `stepNumber` (1–4) and a `section`
+("PLAN" or "START"). Tasks are always assigned to one step.
+
+```json
+// steps.json shape
+{ "steps": [
+    { "stepNumber": 1, "section": "PLAN",  "name": "Plan Your Business",           "timeEstimate": "30 Days" },
+    { "stepNumber": 2, "section": "START", "name": "Register Your Business",        "timeEstimate": "1–5 Days" },
+    { "stepNumber": 3, "section": "START", "name": "After Registering",             "timeEstimate": "30–60 Days" },
+    { "stepNumber": 4, "section": "START", "name": "Before Opening Your Site",      "timeEstimate": "30–60 Days" }
+]}
+```
+
+Three step-set variants exist: `steps.json` (standard), `steps-foreign.json` (foreign entity),
+`steps-domestic-employer.json` (domestic employer). The roadmapBuilder selects the correct set
+based on business persona.
+
+### Layer 2 — Industry Roadmaps (task assignment + within-step ordering)
+
+Each `industries/<id>.json` file lists all tasks for that industry via `roadmapSteps`. Each entry
+specifies:
+- `step` — which step number this task belongs to (1–4)
+- `weight` — sort order within the step (lower = earlier)
+- `task` OR `licenseTask` — filename of the task Markdown (without `.md`)
+- `required` (optional boolean) — whether the task is mandatory
+
+```json
+// industries/restaurant.json (excerpt)
+{ "roadmapSteps": [
+    { "step": 1, "weight": 1,   "task": "business-plan" },
+    { "step": 1, "weight": 50,  "task": "determine-naics-code",    "required": true },
+    { "step": 1, "weight": 100, "task": "business-structure",       "required": true },
+    { "step": 2, "weight": 20,  "task": "register-for-ein",         "required": true },
+    { "step": 2, "weight": 25,  "task": "register-for-taxes",       "required": true },
+    { "step": 4, "weight": 100, "licenseTask": "food-safety-course" }
+]}
+```
+
+**Key point:** Step + weight together define sequencing. Step is a hard grouping; weight is a
+sort key within a step. There is no explicit "must finish A before B can start" within a step
+beyond the weight ordering — that concept lives in the dependency graph (Layer 3).
+
+### Layer 3 — Task Dependencies (prerequisite graph)
+
+`task-dependencies.json` is the central dependency file. It is an array of entries; each entry
+declares what a task `unlockedBy` at runtime:
+
+```json
+// task-dependencies.json shape
+{ "dependencies": [
+    {
+      "task": "register-for-ein",          // the dependent task (filename without .md)
+      "taskDependencies": [                 // prerequisite tasks (any of these must be complete)
+        "form-business-entity",
+        "form-business-entity-nj",
+        "form-business-entity-foreign",
+        "form-business-entity-llc"
+      ]
+    },
+    {
+      "task": "register-for-taxes",
+      "taskDependencies": [
+        "form-business-entity", "form-business-entity-nj",
+        "form-business-entity-foreign", "form-business-entity-llc",
+        "register-for-ein", "determine-naics-code"
+      ]
+    },
+    {
+      "licenseTask": "conversion-license-cannabis",  // can refer to a licenseTask instead
+      "taskDependencies": ["zoning-cannabis"],
+      "licenseTaskDependencies": ["conditional-permit-cannabis"]
+    }
+]}
+```
+
+Fields:
+- `task` / `licenseTask` — the task that has prerequisites (mutually exclusive)
+- `taskDependencies` — list of regular task filenames that must be complete first
+- `licenseTaskDependencies` — list of license-task filenames that must be complete first
+
+Both `taskDependencies` and `licenseTaskDependencies` can appear together on the same entry
+(see the cannabis example above).
+
+At runtime, `loadTasks.ts` / `fetchTaskByFilename.ts` reads this file and attaches the
+`unlockedBy: TaskLink[]` array to each `Task` object. The UI uses this to show locked/unlocked
+state and to grey out tasks that have incomplete prerequisites.
+
+### Layer 4 — Add-Ons (conditional task injection)
+
+`add-ons/<id>.json` files follow the same `roadmapSteps` shape as industry files. They inject
+additional tasks (or modifications) into the roadmap when a user answers certain onboarding
+questions (e.g., "Do you have a boiler?"). The roadmapBuilder merges these into the task list
+and deduplicates.
+
+An add-on can also carry `modifications` (via `TaskModification`) to replace one task filename
+with another, allowing context-specific task variants.
+
+### Layer 5 — Non-Essential Questions
+
+`nonEssentialQuestions.json` defines optional questions that, if answered affirmatively, trigger
+add-ons to be applied. It is a separate mechanism from onboarding questions stored in industry
+`industryOnboardingQuestions`.
+
+---
+
+## TypeScript Interfaces (key ones)
+
+All canonical type definitions live in `shared/src/types/types.ts`:
+
+```typescript
+interface Roadmap {
+  steps: Step[];
+  tasks: Task[];
+}
+
+interface Step {
+  stepNumber: number;
+  name: string;
+  timeEstimate: string;
+  description: string;
+  section: SectionType;  // "PLAN" | "START" | "OPERATE"
+}
+
+interface Task {
+  id: string;
+  filename: string;
+  stepNumber?: number;
+  name: string;
+  urlSlug: string;
+  callToActionLink: string;
+  callToActionText: string;
+  contentMd: string;
+  summaryDescriptionMd: string;
+  unlockedBy: TaskLink[];  // populated at runtime from task-dependencies.json
+  required?: boolean;
+  agencyId?: string;
+}
+
+interface TaskLink {
+  name: string;
+  id: string;
+  urlSlug: string;
+  filename: string;
+}
+
+type TaskDependencies = {
+  task?: string;
+  licenseTask?: string;
+  taskDependencies?: string[];
+  licenseTaskDependencies?: string[];
+};
+```
+
+`shared/src/industry.ts` defines:
+
+```typescript
+interface Industry {
+  id: string;
+  roadmapSteps: AddOn[];    // tasks to include + their step/weight assignments
+  modifications?: TaskModification[];
+  // ...
+}
+
+interface AddOn {
+  step: number;
+  weight: number;
+  task?: string;
+  licenseTask?: string;
+}
+
+interface TaskModification {
+  taskToReplaceFilename: string;
+  replaceWithFilename: string;
+}
+```
+
+---
+
+## How the Roadmap Is Assembled (runtime flow)
+
+1. `roadmapBuilder.ts` (`buildRoadmap`) selects the correct steps file (standard / foreign /
+   domestic-employer) based on persona.
+2. It loads `industries/<industryId>.json` and calls `addTasksFromAddOn` to populate the task
+   builder list with `{ filename, step, weight, required }` tuples.
+3. Add-ons passed in from user answers are merged in the same way.
+4. Any `modifications` entries swap one task filename for another.
+5. Duplicate tasks are removed (first occurrence wins).
+6. Tasks are sorted by `(stepNumber, weight)`.
+7. For each task, `fetchTaskByFilename` reads the Markdown file and also reads
+   `task-dependencies.json` to build the `unlockedBy` array.
+8. The final `Roadmap` object trims `unlockedBy` entries that do not exist in the user's roadmap
+   (so you don't show a prerequisite they'll never see).
+
+---
+
+## Task File Format (Markdown with YAML frontmatter)
+
+Each task is a `.md` file with a YAML front-matter block:
+
+```markdown
+---
+id: form-business-entity
+name: Authorize Your Business Entity
+urlSlug: business-entity-auth
+summaryDescriptionMd: "..."
+callToActionLink: https://...
+callToActionText: Authorize My Business
+agencyId: nj-revenue-enterprise-services
+---
+
+## Application Requirements
+- ...
+```
+
+The `id` matches the identifier used in `task-dependencies.json`. The `filename` (without `.md`)
+is used as the cross-reference key everywhere else.
+
+---
+
+## Scale
+
+- ~65 industry roadmaps
+- ~119 tasks in `tasks/`, plus separate directories for license-tasks, municipal-tasks, env-tasks,
+  raffle-bingo-steps
+- ~93 add-ons
+- ~30 dependency relationships in `task-dependencies.json`
+- 4 numbered Steps per standard roadmap (2 sections: PLAN, START)
+
+---
+
+## Downloaded Files in This Directory
+
+```
+roadmaps/
+  task-dependencies.json         <- THE primary dependency graph
+  steps.json                     <- standard step definitions
+  steps-foreign.json             <- foreign entity step definitions
+  steps-domestic-employer.json   <- domestic employer step definitions
+  nonEssentialQuestions.json     <- optional add-on question triggers
+  industries/
+    acupuncture.json, architecture.json, cannabis.json, cosmetology.json,
+    food-truck.json, restaurant.json, retail.json
+  tasks/
+    business-plan.md, check-site-requirements.md, form-business-entity.md,
+    form-business-entity-foreign.md, register-for-ein.md, register-for-taxes.md,
+    search-licenses.md, site-inspection.md
+  add-ons/
+    amber-light.json, boiler.json
+
+shared-types/
+  types.ts               <- Task, Roadmap, Step, TaskDependencies, TaskLink interfaces
+  industry.ts            <- Industry, AddOn, TaskModification interfaces
+  loadTasks.ts           <- server-side task + dependency loading logic
+  roadmapBuilder.ts      <- roadmap assembly algorithm
+  fetchTaskByFilename.ts <- async task + dependency resolution
+```

--- a/reference-data/nj-navigator/roadmaps/add-ons/amber-light.json
+++ b/reference-data/nj-navigator/roadmaps/add-ons/amber-light.json
@@ -1,0 +1,12 @@
+{
+  "id": "amber-light",
+  "displayname": "amber-light",
+  "roadmapSteps": [
+    {
+      "step": 4,
+      "weight": 10,
+      "licenseTask": "flashing-amber-light",
+      "required": true
+    }
+  ]
+}

--- a/reference-data/nj-navigator/roadmaps/add-ons/boiler.json
+++ b/reference-data/nj-navigator/roadmaps/add-ons/boiler.json
@@ -1,0 +1,13 @@
+{
+  "id": "boiler",
+  "displayname": "boiler",
+  "roadmapSteps": [
+    {
+      "step": 4,
+      "weight": 20,
+      "licenseTask": "boiler-inspection",
+      "task": "boiler-inspection",
+      "required": true
+    }
+  ]
+}

--- a/reference-data/nj-navigator/roadmaps/industries/acupuncture.json
+++ b/reference-data/nj-navigator/roadmaps/industries/acupuncture.json
@@ -1,0 +1,74 @@
+{
+  "naicsCodes": "621399",
+  "defaultSectorId": "health-care-and-social-assistance",
+  "canHavePermanentLocation": true,
+  "roadmapSteps": [
+    {
+      "step": 1,
+      "weight": 1,
+      "task": "business-plan"
+    },
+    {
+      "step": 1,
+      "weight": 50,
+      "task": "determine-naics-code",
+      "required": true
+    },
+    {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
+      "step": 2,
+      "weight": 20,
+      "task": "register-for-ein",
+      "required": true
+    },
+    {
+      "step": 2,
+      "weight": 25,
+      "task": "register-for-taxes",
+      "required": true
+    },
+    {
+      "step": 3,
+      "weight": 10,
+      "task": "bank-account"
+    },
+    {
+      "step": 3,
+      "weight": 15,
+      "task": "get-insurance"
+    },
+    {
+      "step": 4,
+      "weight": 99,
+      "task": "manage-business-vehicles"
+    },
+    {
+      "step": 4,
+      "licenseTask": "rmw-generator-registration",
+      "required": true,
+      "weight": 3
+    },
+    {
+      "step": 4,
+      "weight": 1,
+      "licenseTask": "license-acupuncture",
+      "required": true
+    }
+  ],
+  "name": "Acupuncture",
+  "nonEssentialQuestionsIds": [],
+  "displayname": "acupuncture",
+  "industryOnboardingQuestions": {
+    "canBeHomeBased": true
+  },
+  "isEnabled": true,
+  "additionalSearchTerms": "acupuncturist, spa, alternative medicine",
+  "id": "acupuncture",
+  "description": "Traditional Chinese medicine involving the insertion of needles into the body",
+  "webflowId": "656a136266a0b2c046a17462"
+}

--- a/reference-data/nj-navigator/roadmaps/industries/architecture.json
+++ b/reference-data/nj-navigator/roadmaps/industries/architecture.json
@@ -1,0 +1,85 @@
+{
+  "naicsCodes": "541310, 925120",
+  "defaultSectorId": "construction",
+  "canHavePermanentLocation": true,
+  "roadmapSteps": [
+    {
+      "step": 1,
+      "weight": 1,
+      "task": "business-plan"
+    },
+    {
+      "step": 1,
+      "weight": 50,
+      "task": "determine-naics-code",
+      "required": true
+    },
+    {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
+      "step": 2,
+      "weight": 20,
+      "task": "register-for-ein",
+      "required": true
+    },
+    {
+      "step": 2,
+      "weight": 25,
+      "task": "register-for-taxes",
+      "required": true
+    },
+    {
+      "step": 3,
+      "weight": 10,
+      "task": "bank-account"
+    },
+    {
+      "step": 3,
+      "weight": 15,
+      "task": "get-insurance"
+    },
+    {
+      "step": 4,
+      "weight": 20,
+      "licenseTask": "architect-license",
+      "required": true
+    },
+    {
+      "step": 4,
+      "weight": 25,
+      "task": "architect-are-exam",
+      "required": true
+    },
+    {
+      "step": 4,
+      "weight": 30,
+      "licenseTask": "authorization-architect-firm",
+      "required": true
+    },
+    {
+      "step": 4,
+      "weight": 1,
+      "licenseTask": "professional-planner-license"
+    },
+    {
+      "step": 4,
+      "weight": 99,
+      "task": "manage-business-vehicles"
+    }
+  ],
+  "name": "Architecture and Urban Planning ",
+  "nonEssentialQuestionsIds": [],
+  "displayname": "architecture",
+  "industryOnboardingQuestions": {
+    "canBeHomeBased": true
+  },
+  "isEnabled": true,
+  "additionalSearchTerms": "architect, engineer, consulting, architectural services, planning, firm, professional services, urban planning, land use, landscape architect, regional planning",
+  "id": "architecture",
+  "description": "Plans, designs, and manages the development of buildings, cities, and regions",
+  "webflowId": "656a13629e1c371e9fc59cbd"
+}

--- a/reference-data/nj-navigator/roadmaps/industries/cannabis.json
+++ b/reference-data/nj-navigator/roadmaps/industries/cannabis.json
@@ -1,0 +1,109 @@
+{
+  "naicsCodes": "111419, 111998, 424590, 459991",
+  "defaultSectorId": "cannabis",
+  "canHavePermanentLocation": false,
+  "roadmapSteps": [
+    {
+      "step": 1,
+      "weight": 3,
+      "task": "cannabis-evaluate-location"
+    },
+    {
+      "step": 1,
+      "weight": 50,
+      "task": "determine-naics-code",
+      "required": true
+    },
+    {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
+      "step": 2,
+      "weight": 20,
+      "task": "register-for-ein",
+      "required": true
+    },
+    {
+      "step": 2,
+      "weight": 25,
+      "task": "register-for-taxes",
+      "required": true
+    },
+    {
+      "step": 3,
+      "weight": 1,
+      "task": "cannabis-bank-account"
+    },
+    {
+      "step": 3,
+      "weight": 2,
+      "task": "cannabis-insurance-policy"
+    },
+    {
+      "step": 3,
+      "weight": 3,
+      "task": "priority-status-cannabis",
+      "required": true
+    },
+    {
+      "step": 3,
+      "weight": 5,
+      "task": "zoning-cannabis",
+      "required": true
+    },
+    {
+      "step": 3,
+      "weight": 6,
+      "task": "cannabis-sign-lease"
+    },
+    {
+      "weight": 7,
+      "step": 3,
+      "task": "cannabis-site-requirements"
+    },
+    {
+      "step": 3,
+      "weight": 8,
+      "task": "building-permit"
+    },
+    {
+      "step": 4,
+      "weight": 35,
+      "licenseTask": "town-mercantile-license"
+    },
+    {
+      "step": 4,
+      "weight": 99,
+      "task": "manage-business-vehicles"
+    },
+    {
+      "step": 4,
+      "weight": 36,
+      "task": "env-requirements",
+      "required": false
+    }
+  ],
+  "name": "Cannabis",
+  "nonEssentialQuestionsIds": [
+    "weights-measures",
+    "inspect-boiler",
+    "business-vehicle-irp",
+    "inspect-pv",
+    "inspect-fridge",
+    "bus-initial-inspection",
+    "cdl-neq"
+  ],
+  "displayname": "cannabis",
+  "industryOnboardingQuestions": {
+    "isCannabisLicenseTypeApplicable": true
+  },
+  "modifications": [],
+  "isEnabled": true,
+  "additionalSearchTerms": "marijuana, ATC, cannabis business, micro license, cultivation, cultivator, dispensary, grow, retail, pot, weed, manufacturer, wholesaler, distributor, retailer, delivery",
+  "id": "cannabis",
+  "description": "A business that manufactures, delivers, or sells cannabis",
+  "webflowId": "656a1362657b7f011c19dc79"
+}

--- a/reference-data/nj-navigator/roadmaps/industries/cosmetology.json
+++ b/reference-data/nj-navigator/roadmaps/industries/cosmetology.json
@@ -1,0 +1,97 @@
+{
+  "naicsCodes": "812112, 812199, 812113, 611511, 812111",
+  "defaultSectorId": "other-services",
+  "canHavePermanentLocation": true,
+  "roadmapSteps": [
+    {
+      "step": 1,
+      "weight": 1,
+      "task": "business-plan"
+    },
+    {
+      "step": 1,
+      "weight": 50,
+      "task": "determine-naics-code",
+      "required": true
+    },
+    {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
+      "step": 2,
+      "weight": 20,
+      "task": "register-for-ein",
+      "required": true
+    },
+    {
+      "step": 2,
+      "weight": 25,
+      "task": "register-for-taxes",
+      "required": true
+    },
+    {
+      "step": 3,
+      "weight": 10,
+      "task": "bank-account"
+    },
+    {
+      "step": 3,
+      "weight": 15,
+      "task": "get-insurance"
+    },
+    {
+      "step": 4,
+      "weight": 8,
+      "licenseTask": "apply-for-shop-license",
+      "required": true
+    },
+    {
+      "step": 4,
+      "licenseTask": "cosmetology-license",
+      "weight": 12,
+      "required": true
+    },
+    {
+      "step": 4,
+      "weight": 17,
+      "task": "resale-tax-certificate-operating"
+    },
+    {
+      "step": 4,
+      "weight": 18,
+      "task": "env-requirements",
+      "required": false
+    },
+    {
+      "step": 4,
+      "weight": 99,
+      "task": "manage-business-vehicles"
+    }
+  ],
+  "name": "Cosmetology",
+  "nonEssentialQuestionsIds": ["electrologist"],
+  "displayname": "cosmetology",
+  "industryOnboardingQuestions": {},
+  "modifications": [
+    {
+      "taskToReplaceFilename": "check-site-requirements",
+      "replaceWithFilename": "check-site-requirements-cosmetology"
+    },
+    {
+      "taskToReplaceFilename": "site-safety-permits",
+      "replaceWithFilename": "site-safety-permits-cosmetology"
+    },
+    {
+      "taskToReplaceFilename": "evaluate-your-location",
+      "replaceWithFilename": "evaluate-your-location-cosmetology"
+    }
+  ],
+  "isEnabled": true,
+  "additionalSearchTerms": "cosmetics, beautician, aesthetician, hair salon, barber shop, hair stylist, nail salon, skin care, hair braiding, makeup, studio, electrolysis, electrologist",
+  "id": "cosmetology",
+  "description": "Offering hair, nail, or skin related services",
+  "webflowId": "656a13627f0131f68c389665"
+}

--- a/reference-data/nj-navigator/roadmaps/industries/food-truck.json
+++ b/reference-data/nj-navigator/roadmaps/industries/food-truck.json
@@ -1,0 +1,121 @@
+{
+  "naicsCodes": "722330",
+  "defaultSectorId": "accommodation-and-food-services",
+  "canHavePermanentLocation": false,
+  "roadmapSteps": [
+    {
+      "step": 1,
+      "weight": 1,
+      "task": "business-plan"
+    },
+    {
+      "step": 1,
+      "weight": 3,
+      "task": "evaluate-your-location"
+    },
+    {
+      "step": 1,
+      "weight": 50,
+      "task": "determine-naics-code",
+      "required": true
+    },
+    {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
+      "step": 2,
+      "weight": 20,
+      "task": "register-for-ein",
+      "required": true
+    },
+    {
+      "step": 2,
+      "weight": 25,
+      "task": "register-for-taxes",
+      "required": true
+    },
+    {
+      "step": 3,
+      "weight": 1,
+      "task": "bank-account"
+    },
+    {
+      "step": 3,
+      "weight": 2,
+      "licenseTask": "apply-for-food-truck-license",
+      "required": true
+    },
+    {
+      "step": 3,
+      "weight": 3,
+      "task": "zoning-food-truck"
+    },
+    {
+      "step": 3,
+      "weight": 3,
+      "task": "sign-lease-food-truck"
+    },
+    {
+      "step": 3,
+      "weight": 7,
+      "task": "get-insurance"
+    },
+    {
+      "step": 4,
+      "weight": 1,
+      "task": "transportation-entity-id",
+      "required": true
+    },
+    {
+      "step": 4,
+      "weight": 2,
+      "task": "mvc-title-task",
+      "required": true
+    },
+    {
+      "step": 4,
+      "weight": 3,
+      "task": "mvc-registration-task",
+      "required": true
+    },
+    {
+      "step": 4,
+      "weight": 4,
+      "licenseTask": "fire-permit-food-truck",
+      "required": true
+    },
+    {
+      "step": 4,
+      "weight": 5,
+      "licenseTask": "town-mercantile-license"
+    },
+    {
+      "step": 4,
+      "weight": 6,
+      "task": "resale-tax-certificate-operating"
+    },
+    {
+      "step": 4,
+      "weight": 7,
+      "licenseTask": "food-safety-course"
+    },
+    {
+      "weight": 8,
+      "step": 4,
+      "task": "trucking-cdl",
+      "required": true
+    }
+  ],
+  "name": "Food Truck",
+  "nonEssentialQuestionsIds": ["weights-measures"],
+  "displayname": "food-truck",
+  "industryOnboardingQuestions": {},
+  "isEnabled": true,
+  "additionalSearchTerms": "lunch wagon,food service truck,street food,food cart,fast food cart, food vendor",
+  "id": "food-truck",
+  "description": "A vehicle where food or beverages are transported, stored, or prepared for sale at temporary locations",
+  "webflowId": "656a136253b505573055370f"
+}

--- a/reference-data/nj-navigator/roadmaps/industries/restaurant.json
+++ b/reference-data/nj-navigator/roadmaps/industries/restaurant.json
@@ -1,0 +1,90 @@
+{
+  "naicsCodes": "722511, 722310, 722320, 722410, 722513, 722514, 722515",
+  "defaultSectorId": "accommodation-and-food-services",
+  "canHavePermanentLocation": true,
+  "roadmapSteps": [
+    {
+      "step": 1,
+      "weight": 1,
+      "task": "business-plan"
+    },
+    {
+      "step": 1,
+      "weight": 50,
+      "task": "determine-naics-code",
+      "required": true
+    },
+    {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
+      "step": 2,
+      "weight": 20,
+      "task": "register-for-ein",
+      "required": true
+    },
+    {
+      "step": 2,
+      "weight": 25,
+      "task": "register-for-taxes",
+      "required": true
+    },
+    {
+      "step": 3,
+      "weight": 10,
+      "task": "bank-account"
+    },
+    {
+      "step": 3,
+      "weight": 15,
+      "task": "get-insurance"
+    },
+    {
+      "step": 4,
+      "weight": 15,
+      "task": "floor-plan-approval-doh",
+      "required": true
+    },
+    {
+      "step": 4,
+      "weight": 100,
+      "licenseTask": "food-safety-course"
+    },
+    {
+      "step": 4,
+      "weight": 16,
+      "task": "env-requirements",
+      "required": false
+    },
+    {
+      "step": 4,
+      "weight": 90,
+      "task": "resale-tax-certificate-operating"
+    },
+    {
+      "step": 4,
+      "weight": 99,
+      "task": "manage-business-vehicles"
+    }
+  ],
+  "name": "Restaurant",
+  "nonEssentialQuestionsIds": [
+    "weights-measures",
+    "inspect-boiler",
+    "inspect-pv",
+    "inspect-fridge",
+    "sell-milk-question"
+  ],
+  "displayname": "restaurant",
+  "industryOnboardingQuestions": {
+    "isLiquorLicenseApplicable": true
+  },
+  "isEnabled": true,
+  "additionalSearchTerms": "cafe, grill",
+  "id": "restaurant",
+  "description": "Provides food to patrons",
+  "webflowId": "656a1362e1f1359c3c90e9eb"
+}

--- a/reference-data/nj-navigator/roadmaps/industries/retail.json
+++ b/reference-data/nj-navigator/roadmaps/industries/retail.json
@@ -1,0 +1,89 @@
+{
+  "naicsCodes": "459920, 441330, 445320, 459210, 458110, 445131, 456120, 455110, 449210, 445250, 449121, 459310, 456191, 449110, 459420, 444140, 459120, 458310, 458320, 445240, 441227, 459140, 444240, 459410, 456130, 444180, 444230, 459910, 459130, 458210, 459110, 441340, 459991, 459510, 455211, 449122, 455219, 456199, 449129, 459999, 445298",
+  "defaultSectorId": "retail-trade-and-ecommerce",
+  "canHavePermanentLocation": true,
+  "roadmapSteps": [
+    {
+      "step": 1,
+      "weight": 1,
+      "task": "business-plan"
+    },
+    {
+      "step": 1,
+      "weight": 50,
+      "task": "determine-naics-code",
+      "required": true
+    },
+    {
+      "step": 1,
+      "weight": 100,
+      "task": "business-structure",
+      "required": true
+    },
+    {
+      "step": 2,
+      "weight": 20,
+      "task": "register-for-ein",
+      "required": true
+    },
+    {
+      "step": 2,
+      "weight": 25,
+      "task": "register-for-taxes",
+      "required": true
+    },
+    {
+      "step": 3,
+      "weight": 10,
+      "task": "bank-account"
+    },
+    {
+      "step": 3,
+      "weight": 15,
+      "task": "get-insurance"
+    },
+    {
+      "step": 4,
+      "weight": 10,
+      "task": "search-licenses-retail"
+    },
+    {
+      "step": 4,
+      "weight": 14,
+      "task": "env-requirements",
+      "required": false
+    },
+    {
+      "step": 4,
+      "weight": 20,
+      "task": "resale-tax-certificate-operating"
+    },
+    {
+      "step": 4,
+      "weight": 99,
+      "task": "manage-business-vehicles"
+    }
+  ],
+  "name": "Retail",
+  "nonEssentialQuestionsIds": [
+    "ticket-broker-resell",
+    "weights-measures",
+    "cigarette-manufacture-sell",
+    "other-businesses-CRTK-survey",
+    "retail-pesticide-dealer-licensing",
+    "inspect-boiler",
+    "business-vehicle-irp",
+    "inspect-pv",
+    "inspect-fridge",
+    "sell-milk-question",
+    "cdl-neq",
+    "streamlined-sales-tax-registration"
+  ],
+  "displayname": "retail",
+  "industryOnboardingQuestions": {},
+  "isEnabled": true,
+  "additionalSearchTerms": "clothing, clothing accessories, store, reseller, outlet, shop, thrift store, candle store, crafts/hobby store, clothing store, consignment, boutique, sales, grocery store, food retail, flower shop, florist, custom frames, deli, convenience store, candy store, jewelry store, apparel retail, thrift store, gift shop, bike shop, bookstore, yarn shop, goods retail, accessories retail, ",
+  "id": "retail",
+  "description": "Selling or reselling goods in a brick and mortar location outside of your home",
+  "webflowId": "656a13629d57077e647ddf9f"
+}

--- a/reference-data/nj-navigator/roadmaps/nonEssentialQuestions.json
+++ b/reference-data/nj-navigator/roadmaps/nonEssentialQuestions.json
@@ -1,0 +1,385 @@
+{
+  "nonEssentialQuestionsArray": [
+    {
+      "id": "ticket-broker-resell",
+      "questionText": "Do you plan to resell admission tickets to places of entertainment and charge more than the original price?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "ticket-broker-reseller"
+    },
+    {
+      "id": "multiple-dwelling-register",
+      "questionText": "Do you plan to own a multiple dwelling, such as an apartment or condominium complex?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "multiple-dwelling-registration"
+    },
+    {
+      "id": "hotel-register",
+      "questionText": "Do you plan to own a hotel, motel, or guesthouse with 10 rooms or more?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "lodging-hotel-registration"
+    },
+    {
+      "id": "carnival-ride-permitting",
+      "questionText": "Do you plan to own and/or operate a carnival or amusement ride?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "entertainment-carnival-ride-permit",
+      "anytimeActions": [
+        "carnival-ride-supplemental-modification",
+        "operating-carnival-fire-permit"
+      ]
+    },
+    {
+      "id": "carnival-fire-licenses",
+      "questionText": "Do you plan to own and/or operate a traveling carnival or circus?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "entertainment-carnival-fire-licenses",
+      "anytimeActions": [
+        "operating-carnival-fire-permit"
+      ]
+    },
+    {
+      "id": "hotel-food",
+      "questionText": "Do you plan to serve food?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "lodging-food"
+    },
+    {
+      "id": "hotel-liquor",
+      "questionText": "Do you plan to serve liquor, including beer or wine?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "lodging-liquor"
+    },
+    {
+      "addOnWhenNo": "",
+      "addOnWhenYes": "weights-measures-add",
+      "id": "weights-measures",
+      "questionText": "Do you plan to use a weighing or measuring device, such as a scale or meter, for your business?"
+    },
+    {
+      "questionText": "Are you a dentist?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "healthcare-dentist",
+      "id": "dentist"
+    },
+    {
+      "questionText": "Does your dental office generate `amalgam waste|amalgam-waste` ?",
+      "addOnWhenYes": "dental-waste-registration",
+      "id": "dental-amalgam-waste",
+      "addOnWhenNo": "dental-waste-exemption"
+    },
+    {
+      "id": "special-permit-dentistry",
+      "questionText": "Do you specialize in any area of dentistry, such as orthodontics or oral surgery?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "healthcare-dental-specialty"
+    },
+    {
+      "id": "dental-hygienist",
+      "questionText": "Are you a dental hygienist?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "healthcare-dental-hygienist"
+    },
+    {
+      "id": "freestanding-residential-health-care-license",
+      "questionText": "Do you plan to own and/or operate a `free-standing residential health care facility?|residential-health-care-facility`",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "healthcare-freestanding-facility-license"
+    },
+    {
+      "id": "rooming-boarding-house-owner",
+      "questionText": "Do you plan to own and/or operate a rooming or boarding house?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "lodging-rooming-boarding-house"
+    },
+    {
+      "addOnWhenNo": "",
+      "addOnWhenYes": "entertainment-agency-registration",
+      "id": "entertainment-agency-register",
+      "questionText": "Do you plan to provide entertainment booking services in New Jersey?"
+    },
+    {
+      "questionText": "Do you plan to offer electrologist/electrolysis services?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "cosmetology-electrologist-license",
+      "id": "electrologist"
+    },
+    {
+      "id": "petcare-cds-shelter",
+      "questionText": "Do you plan to store sodium pentobarbital for animal euthanasia?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "petcare-shelter"
+    },
+    {
+      "id": "petcare-cds-trainer",
+      "questionText": "Do you plan to train dogs to detect illegal substances?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "petcare-trainer"
+    },
+    {
+      "id": "cds-lab-research ",
+      "questionText": "Do you plan to test or research Controlled Dangerous Substances (CDS)?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "other-lab-research"
+    },
+    {
+      "questionText": "Do you plan to make, buy, or sell products that contain Controlled Dangerous Substances (CDS)?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "other-cds-supply",
+      "id": "cds-supply"
+    },
+    {
+      "questionText": "Do you plan to sell cigarettes, have a cigarette vending machine, or be a cigarette manufacturer sales representative?",
+      "id": "cigarette-manufacture-sell",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "cigarettes-add"
+    },
+    {
+      "addOnWhenNo": "",
+      "addOnWhenYes": "planner",
+      "id": "planning-services",
+      "questionText": "Do you plan to offer professional planning services?"
+    },
+    {
+      "addOnWhenNo": "",
+      "addOnWhenYes": "healthcare-xray-reg",
+      "id": "healthcare-xray-regis",
+      "questionText": "Do you plan to be using x-ray machines?",
+      "anytimeActions": [
+        "temp-xray-registration",
+        "xray-disposition-form"
+      ]
+    },
+    {
+      "questionText": "Are you an optometrist?",
+      "id": "healthcare-optometrist ",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "healthcare-tpa"
+    },
+    {
+      "questionText": "Do you plan to deliver packages by air (for example, by airplane or helicopter)?",
+      "id": "courier-CRTK-survey",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "community-rtk-survey"
+    },
+    {
+      "questionText": "Do you plan to fall under [one of these industries](https://www.nj.gov/dep/enforcement/opppc/crtk/rtknaics.pdf)?",
+      "id": "other-businesses-CRTK-survey",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "community-rtk-survey"
+    },
+    {
+      "questionText": "Do you plan to sell lawn and garden supplies, flowers, or florists' supplies?",
+      "id": "lawn-businesses-CRTK-survey",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "community-rtk-survey"
+    },
+    {
+      "questionText": "Do you plan to do management consulting services (not including manufacturing management, physical distribution, and site location consulting)?",
+      "id": "logistics-CRTK-survey",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "community-rtk-survey"
+    },
+    {
+      "id": "pest-pesticide-dealer-licensing",
+      "questionText": "Do you plan to sell pesticides?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "pest-pesticide-dealer-license",
+      "anytimeActions": [
+        "pesticide-dealer-license-renewal",
+        "pesticide-dealer-business-license"
+      ]
+    },
+    {
+      "id": "retail-pesticide-dealer-licensing",
+      "questionText": "Do you plan to sell pesticides?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "retail-pesticide-dealer-license",
+      "anytimeActions": [
+        "pesticide-dealer-license-renewal",
+        "pesticide-dealer-business-license"
+      ]
+    },
+    {
+      "id": "pesticides-applicator-licensing",
+      "questionText": "Do you plan to use pesticides or offer pesticide application services?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "multi-pest-applicator-license",
+      "anytimeActions": [
+        "commercial-pest-applicator-license-recert",
+        "commercial-pest-applicator-license-renewal",
+        "pesticide-applicator-business-license-renewal"
+      ]
+    },
+    {
+      "id": "crematory",
+      "questionText": "Will you be constructing and/or operating a crematory?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "crematory-application-funeral"
+    },
+    {
+      "questionText": "Will your business or facility use a boiler with a significant heating capacity?",
+      "id": "inspect-boiler",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "boiler"
+    },
+    {
+      "id": "regulated-medical-waste-question",
+      "questionText": "Will your business have `Regulated Medical Waste (RMW)|regulated-medical-waste` ?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "regulated-medical-waste-generator-registration"
+    },
+    {
+      "id": "business-vehicle-irp",
+      "questionText": "Will you operate vehicles over 26,000 pounds, or that have 3 or more axles, in 2 or more states or Canadian provinces?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "vehicle-irp"
+    },
+    {
+      "id": "inspect-pv",
+      "questionText": "Will your business or facility use a large pressure vessel (a vessel without a \"UM\" stamp)?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "pv-certificate"
+    },
+    {
+      "id": "inspect-fridge",
+      "questionText": "Will your business or facility use a large refrigerator or cooling system?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "refrigeration-certificate"
+    },
+    {
+      "id": "bus-initial-inspection",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "transportation-initial-inspection",
+      "questionText": "Will your business use commercial vehicles, such as school or shuttle buses, to transport passengers?"
+    },
+    {
+      "id": "insurance-producer",
+      "questionText": "Will you sell, solicit, or negotiate insurance products?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "produce-insurance"
+    },
+    {
+      "id": "sell-milk-question",
+      "questionText": "Will you sell milk or other milk products, such as yogurt or cream?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "sell-milk"
+    },
+    {
+      "id": "resale-tax-cert",
+      "questionText": "Will you buy products for resale, or will you sell products to resellers?",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "resale-certificate",
+      "anytimeActions": [
+        "resale-tax-certificate"
+      ]
+    },
+    {
+      "addOnWhenNo": "",
+      "addOnWhenYes": "vehicle-cpcn",
+      "questionText": "Will your business provide intrastate transportation of passengers to and from **casinos in Atlantic city,** or **in exchange for compensation** from passengers or groups?",
+      "id": "mvc-cpcn"
+    },
+    {
+      "id": "demo-only",
+      "questionText": "You are a demo industry user. This is an example non-essential question that is being used to add an Anytime Action. Answering \"yes\" will add the Anytime Action \"Demo Anytime Action\".",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "",
+      "anytimeActions": [
+        "demo-only"
+      ]
+    },
+    {
+      "id": "well-driller",
+      "questionText": "Do you plan to install, repair, or modify wells for your customer's business?\n",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "construction-well-driller-license"
+    },
+    {
+      "addOnWhenNo": "",
+      "addOnWhenYes": "vehicle-dealership-neq",
+      "anytimeActions": [],
+      "id": "vehicle-dealership-q",
+      "questionText": "Will your business sell or lease 4 or more vehicles or boats in a given year?"
+    },
+    {
+      "addOnWhenNo": "",
+      "addOnWhenYes": "cdl-addOnWhenYes",
+      "anytimeActions": [],
+      "id": "cdl-neq",
+      "questionText": "Will your business use commercial vehicles weighing over 26,000 pounds to haul loads or transport passengers?"
+    },
+    {
+      "anytimeActions": [],
+      "questionText": "Will you or your company work with asbestos?",
+      "id": "asbestos-abatement-question",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "notify-asbestos"
+    },
+    {
+      "anytimeActions": [
+        "ust-modification",
+        "ust-registration-renewal"
+      ],
+      "id": "ust-reg",
+      "questionText": "Does your business have an underground storage tank?"
+    },
+    {
+      "anytimeActions": [],
+      "questionText": "Do you plan to transport solid or medical waste generated by your business?",
+      "id": "selfgenerator-transporter-registration",
+      "addOnWhenYes": "registration-selfgenerator-waste-transp"
+    },
+    {
+      "anytimeActions": [],
+      "id": "streamlined-sales-tax-registration",
+      "questionText": "Do you plan to sell products or services in other states?",
+      "addOnWhenYes": "nj-seller-streamlined-sales-tax"
+    },
+    {
+      "anytimeActions": [],
+      "questionText": "Do you plan to transport solid or medical waste generated by other people or businesses?",
+      "id": "waste-transporter-license-a-901",
+      "addOnWhenYes": "waste-transporter-license"
+    },
+    {
+      "anytimeActions": [],
+      "questionText": "Will you use flashing amber (yellow) lights on your business vehicle?",
+      "addOnWhenYes": "amber-light",
+      "id": "flashing-light-permit"
+    },
+    {
+      "questionText": "Will your business fall under [one of these industries](https://www.nj.gov/dep/enforcement/opppc/reports/rtknaics.pdf)?",
+      "id": "crtk-applicable-naics-codes",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "community-rtk-survey"
+    },
+    {
+      "questionText": "Do you own a vacant or unoccupied property in New Jersey with a total floor space of 2,500 square feet or more?",
+      "id": "vacantPropertyOwner",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "",
+      "anytimeActions": [
+        "vacant-building-fire-permit"
+      ]
+    },
+    {
+      "questionText": "Do you own and/or operate a `carnival or amusement ride|carnival-amusement-ride` ?",
+      "id": "carnivalRideOwningBusiness",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "",
+      "anytimeActions": [
+        "carnival-ride-supplemental-modification",
+        "operating-carnival-fire-permit]"
+      ]
+    },
+    {
+      "questionText": "Do you own and/or operate a traveling carnival or circus?",
+      "id": "travelingCircusOrCarnivalOwningBusiness",
+      "addOnWhenNo": "",
+      "addOnWhenYes": "",
+      "anytimeActions": [
+        "operating-carnival-fire-permit"
+      ]
+    }
+  ]
+}

--- a/reference-data/nj-navigator/roadmaps/steps-domestic-employer.json
+++ b/reference-data/nj-navigator/roadmaps/steps-domestic-employer.json
@@ -1,0 +1,11 @@
+{
+  "steps": [
+    {
+      "section": "DOMESTIC_EMPLOYER_SECTION",
+      "stepNumber": 1,
+      "name": "Register as an Employer",
+      "timeEstimate": "",
+      "description": ""
+    }
+  ]
+}

--- a/reference-data/nj-navigator/roadmaps/steps-foreign.json
+++ b/reference-data/nj-navigator/roadmaps/steps-foreign.json
@@ -1,0 +1,11 @@
+{
+  "steps": [
+    {
+      "section": "START",
+      "stepNumber": 1,
+      "name": "Ensure Your Out-of-State Business Complies with New Jersey Laws",
+      "timeEstimate": "1 month",
+      "description": "Get legally recognized by the State and federal government so you can start acting on behalf of your business."
+    }
+  ]
+}

--- a/reference-data/nj-navigator/roadmaps/steps.json
+++ b/reference-data/nj-navigator/roadmaps/steps.json
@@ -1,0 +1,32 @@
+{
+  "steps": [
+    {
+      "section": "PLAN",
+      "stepNumber": 1,
+      "name": "Plan Your ${OoS} Business",
+      "timeEstimate": "30 Days",
+      "description": "Have a strong plan in place to make later decisions and filings easier and more predictable."
+    },
+    {
+      "section": "START",
+      "stepNumber": 2,
+      "name": "Register Your ${OoS} Business",
+      "timeEstimate": "1\u20135 Days",
+      "description": "Get legally recognized by the State and federal government so you can start acting on behalf of your business."
+    },
+    {
+      "section": "START",
+      "stepNumber": 3,
+      "name": "After Registering Your ${OoS} Business",
+      "timeEstimate": "30\u201360 Days",
+      "description": "Enter insurance and/or location agreements in your business's name to protect both you and your business legally."
+    },
+    {
+      "section": "START",
+      "stepNumber": 4,
+      "name": "Before Opening Your Site in New Jersey",
+      "timeEstimate": "30\u201360 Days",
+      "description": "Obtain industry-specific approvals or inspections to make sure you're in compliance with State or local laws before opening."
+    }
+  ]
+}

--- a/reference-data/nj-navigator/roadmaps/task-dependencies.json
+++ b/reference-data/nj-navigator/roadmaps/task-dependencies.json
@@ -1,0 +1,211 @@
+{
+  "dependencies": [
+    {
+      "task": "register-for-ein",
+      "taskDependencies": [
+        "form-business-entity",
+        "form-business-entity-nj",
+        "form-business-entity-foreign",
+        "form-business-entity-llc"
+      ]
+    },
+    {
+      "task": "form-business-entity",
+      "taskDependencies": [
+        "register-for-ein"
+      ]
+    },
+    {
+      "task": "register-for-taxes",
+      "taskDependencies": [
+        "form-business-entity",
+        "form-business-entity-nj",
+        "form-business-entity-foreign",
+        "form-business-entity-llc",
+        "register-for-ein",
+        "determine-naics-code",
+        "form-business-entity-foreign"
+      ]
+    },
+    {
+      "task": "floor-plan-approval-doh",
+      "taskDependencies": [
+        "sign-lease"
+      ]
+    },
+    {
+      "task": "individual-staff-licenses-health-aide",
+      "licenseTaskDependencies": [
+        "home-health-aide-license"
+      ]
+    },
+    {
+      "task": "site-safety-permits-cosmetology",
+      "taskDependencies": [
+        "sign-lease",
+        "building-permit"
+      ]
+    },
+    {
+      "task": "town-mercantile-license-liquor",
+      "taskDependencies": [
+        "sign-lease",
+        "liquor-license-availability"
+      ]
+    },
+    {
+      "task": "zoning",
+      "taskDependencies": [
+        "sign-lease"
+      ]
+    },
+    {
+      "task": "apply-scorp-federal",
+      "taskDependencies": [
+        "register-for-taxes"
+      ]
+    },
+    {
+      "task": "apply-scorp-state",
+      "taskDependencies": [
+        "apply-scorp-federal"
+      ]
+    },
+    {
+      "licenseTask": "apply-for-shop-license",
+      "taskDependencies": [
+        "site-safety-permits-cosmetology"
+      ]
+    },
+    {
+      "licenseTask": "selfgenerator-waste\u2013transporters-reg",
+      "licenseTaskDependencies": [
+        "register-home-contractor"
+      ]
+    },
+    {
+      "licenseTask": "pharmacy-license",
+      "taskDependencies": [
+        "site-safety-permits"
+      ]
+    },
+    {
+      "licenseTask": "conversion-license-cannabis",
+      "taskDependencies": [
+        "zoning-cannabis"
+      ],
+      "licenseTaskDependencies": [
+        "conditional-permit-cannabis"
+      ]
+    },
+    {
+      "licenseTask": "annual-license-cannabis",
+      "taskDependencies": [
+        "zoning-cannabis",
+        "priority-status-cannabis"
+      ]
+    },
+    {
+      "licenseTask": "conditional-permit-cannabis",
+      "taskDependencies": [
+        "priority-status-cannabis"
+      ]
+    },
+    {
+      "task": "trucking-irp",
+      "taskDependencies": [
+        "trucking-usdot"
+      ]
+    },
+    {
+      "task": "trucking-vehicle-registration",
+      "taskDependencies": [
+        "trucking-insurance"
+      ]
+    },
+    {
+      "task": "register-for-taxes-foreign",
+      "taskDependencies": [
+        "form-business-entity-foreign"
+      ]
+    },
+    {
+      "task": "apply-scorp-federal",
+      "taskDependencies": [
+        "register-for-taxes-foreign"
+      ]
+    },
+    {
+      "task": "form-business-entity-foreign",
+      "taskDependencies": [
+        "certificate-good-standing-foreign"
+      ]
+    },
+    {
+      "licenseTask": "bus-inspection",
+      "taskDependencies": [
+        "school-bus-insurance"
+      ]
+    },
+    {
+      "task": "transportation-inspection",
+      "taskDependencies": [
+        "transport-insurance"
+      ]
+    },
+    {
+      "task": "transportation-cpcn",
+      "taskDependencies": [
+        "transportation-entity-id"
+      ]
+    },
+    {
+      "licenseTask": "daycare-license",
+      "taskDependencies": [
+        "daycare-site-requirements"
+      ]
+    },
+    {
+      "task": "architect-are-exam",
+      "licenseTaskDependencies": [
+        "architect-license"
+      ]
+    },
+    {
+      "licenseTask": "authorization-architect-firm",
+      "licenseTaskDependencies": [
+        "architect-license"
+      ]
+    },
+    {
+      "licenseTask": "auto-body-repair-license",
+      "taskDependencies": [
+        "register-for-taxes"
+      ]
+    },
+    {
+      "licenseTask": "detective-employees",
+      "licenseTaskDependencies": [
+        "detective-agency-license"
+      ]
+    },
+    {
+      "licenseTask": "hvac-license",
+      "taskDependencies": [
+        "hvac-insurance-surety-bond"
+      ]
+    },
+    {
+      "licenseTask": "moving-company-license",
+      "taskDependencies": [
+        "moving-company-insurance"
+      ]
+    },
+    {
+      "licenseTask": "electrical-business-license",
+      "taskDependencies": [
+        "get-insurance"
+      ]
+    }
+  ]
+}

--- a/reference-data/nj-navigator/roadmaps/tasks/business-plan.md
+++ b/reference-data/nj-navigator/roadmaps/tasks/business-plan.md
@@ -1,0 +1,30 @@
+---
+summaryDescriptionMd: >-
+  Your business plan guides your business and helps you make decisions around
+  operations, staffing, marketing, and financing. Learn [how to structure your
+  business plan](https://business.nj.gov/pages/create-a-business-plan).
+
+
+  Data shows that businesses with a plan are more successful. In addition, some state licenses may require you to have a business plan.
+urlSlug: business-plan
+displayname: business-plan
+name: Write Your Business Plan
+id: business-plan
+callToActionLink: ""
+callToActionText: ""
+---
+
+## Business Support
+
+- The U.S. Small Business Administration's [Business Plan Tool](https://www.sba.gov/business-guide/plan-your-business/write-your-business-plan) provides a step-by-step process to update the status of your business plan
+- [The New Jersey Small Business Development Center](https://njsbdc.com/) regional offices are in every county and offer one-on-one support
+- [SCORE](https://www.score.org/) is a national organization with local branches that provides access to volunteer, expert business mentors
+- [The Women's Center for Entrepreneurship of Northern New Jersey](https://www.wcecnj.org/) offers support to all entrepreneurs
+- [The Latin American Economic Development Association of Southern New Jersey](http://www.laeda.com/) offers support to all entrepreneurs
+- [UCEDC](https://ucedc.com/) provides low cost or free classes and paid business mentoring services
+
+:::largeCallout{ showHeader="true" headerText="" calloutType="conditional" amountIconText="" filingTypeIconText="" frequencyIconText="" phoneIconText="" emailIconText="" }
+
+A business plan.
+
+:::

--- a/reference-data/nj-navigator/roadmaps/tasks/check-site-requirements.md
+++ b/reference-data/nj-navigator/roadmaps/tasks/check-site-requirements.md
@@ -1,0 +1,29 @@
+---
+notesMd: Sept 2025 - Added another bullet for Land Use & minor copy edits for
+  plain language
+summaryDescriptionMd: Contact your state or local government to learn what you
+  need to do for your site and business. Before you open, your business site
+  needs to be inspected and approved to make sure it's safe.
+urlSlug: site-requirements
+displayname: site-requirements
+name: Determine Your Site Requirements
+id: check-site-requirements
+callToActionLink: ""
+callToActionText: ""
+---
+## Safety Permits
+
+1. **Fire protection permits**: Talk to your fire department to make sure your space is meeting requirements, like working sprinklers, extinguishers, and signage
+2. **Signs**: Speak to your local zoning office and building/construction department to make sure the signage you're proposing is allowed
+3. **Construction permits**: Check with your local government's building/construction department for permit requirements prior to starting renovations. Find out the [requirements for a construction permit](https://business.nj.gov/pages/building-permits-and-inspections) at your site
+4. **`Certificate of Occupancy or Approval|certificate-occupancy`**: Speak to your local building/construction department to certify that your space is safe for occupancy
+5. **`Life Hazard Use|life-hazard-use` or `Non-Life Hazard Use|non-life-hazard-use` registration**: Contact your `Local Enforcing Agency|lea` to see if you need to register as a Life Hazard Use or Non-Life Hazard Use. Your Use Type depends on whether your business poses a significant fire hazard. Once you identify your Use Type, you will need to register and potentially make construction improvements to your site. Once your business is up and running, your Use Type will determine when and how often your routine fire inspections will occur
+6. **`Land Use|land-use` permits**: Contact the [New Jersey Department of Environmental Protection (NJDEP)](https://dep.nj.gov/wlm/lrp/) to find out if you need a land use permit. You need Land Use permits for any construction project that might affect protected environmental locations like coastal zones, wetlands, and flood-prone areas
+
+:::largeCallout{ showHeader="true" headerText="Once completed, you will know:" calloutType="conditional" }
+
+* The permits and inspections required to open, change, and operate your commercial space
+* The process for getting those permits and inspections
+* The time it takes to receive any permits or licenses
+
+:::

--- a/reference-data/nj-navigator/roadmaps/tasks/form-business-entity-foreign.md
+++ b/reference-data/nj-navigator/roadmaps/tasks/form-business-entity-foreign.md
@@ -1,0 +1,7 @@
+---
+displayname: form-business-entity-foreign
+urlSlug: form-business-entity-foreign
+name: Check Available Names and Authorize Your Business in New Jersey
+id: form-business-entity
+summaryDescriptionMd: ""
+---

--- a/reference-data/nj-navigator/roadmaps/tasks/form-business-entity.md
+++ b/reference-data/nj-navigator/roadmaps/tasks/form-business-entity.md
@@ -1,0 +1,32 @@
+---
+summaryDescriptionMd: To conduct business in New Jersey, you must register your
+  business name and authorize your `business
+  structure|business-structure-contextual-link` with the State.
+urlSlug: business-entity-auth
+displayname: business-entity-auth
+name: Authorize Your Business Entity
+id: form-business-entity
+callToActionLink: https://www.njportal.com/DOR/BusinessFormation/CompanyInformation/BusinessName
+callToActionText: Authorize My Business
+agencyId: nj-revenue-enterprise-services
+---
+
+## Application Requirements
+
+- Business name (same name as in your home state)
+- Business structure
+- [NAICS code](/tasks/naics-code-determination) (optional) ${naicsCode}
+- `EIN|ein` (optional)
+- Business description
+- Business address (this may be a home address if you are a home-based business)
+- `Registered agent|registered-agent`
+- Applicable fees paid
+
+:::largeCallout{ showHeader="true" headerText="" calloutType="conditional" }
+
+- `Entity ID|entity-id-contextual-link`
+- `Certificate of Authorization|certificate-formation`
+- `Certified copy|certified-copy` of Certificate of Authorization (optional with additional fee)
+- `Certificate of Good Standing|good-standing` (optional with additional fee)
+
+:::

--- a/reference-data/nj-navigator/roadmaps/tasks/register-for-ein.md
+++ b/reference-data/nj-navigator/roadmaps/tasks/register-for-ein.md
@@ -1,0 +1,39 @@
+---
+summaryDescriptionMd: >-
+  :::note
+   This screen guides your next steps. It does not submit your information for registration.
+  :::
+
+
+  An `Employer Identification Number (EIN)|ein` is essentially a Social Security Number (SSN) for your business, provided by the federal government. It's better to get an EIN to avoid using your personal SSN on tax filings and business registrations. You need an EIN if you plan to have employees.
+urlSlug: ein-registration
+displayname: ein-registration
+name: Get Your EIN from the IRS
+id: register-for-ein
+callToActionLink: ""
+callToActionText: ""
+agencyAdditionalContext: Internal Revenue Service
+formName: SS-4
+---
+
+## Application Requirements
+
+- Your business name
+
+---
+
+## Next Steps
+
+1. [Get your EIN](https://www.irs.gov/businesses/small-businesses-self-employed/apply-for-an-employer-identification-number-ein-online)
+2. Save your EIN
+
+${einInputComponent}
+
+---
+
+:::largeCallout{ showHeader="true" headerText="" calloutType="conditional" }
+
+- An EIN
+- An EIN Certificate (the document indicating your EIN)
+
+:::

--- a/reference-data/nj-navigator/roadmaps/tasks/register-for-taxes.md
+++ b/reference-data/nj-navigator/roadmaps/tasks/register-for-taxes.md
@@ -1,0 +1,58 @@
+---
+summaryDescriptionMd: >-
+
+
+  :::infoAlert
+   If you registered online, you will receive an email confirmation where you can download your BRC. It may take up to 72 hours before you can download your BRC on a public site. Your PIN may take longer to receive because it is sent through the mail.
+  :::
+
+
+  It's time to register your business for State taxes. Doing so will tell the State more about your business and determine the taxes and employer contributions you're responsible for.
+
+
+  :::note
+   This screen guides your next steps. It does not submit your information for registration.
+  :::
+urlSlug: tax-registration
+displayname: tax-registration
+name: Register Your Business for State Taxes and Employer Purposes
+id: register-for-taxes
+callToActionLink: ""
+callToActionText: ""
+agencyId: nj-revenue-enterprise-services
+formName: NJ-Reg
+---
+
+## Application Requirements
+
+- `Entity ID|entity-id-contextual-link` (not required for general partnership or sole proprietorship)
+- [NAICS code](/tasks/naics-code-determination): ${naicsCode}
+- `EIN|ein`
+- Estimated start date
+- Description of your business activity
+- Estimated number of employees (if applicable)
+- Anticipated first payroll withholding date for employees (if applicable)
+- Information on if and when you expect to report and collect sales tax
+- Owner information
+- Mail to address and business location(s)
+- Other taxes you may collect (e.g., motor fuels and cigarette/tobacco taxes), a list will be provided
+
+---
+
+## Next Steps
+
+1. [Register for State Taxes](https://www.njportal.com/DOR/BusinessRegistration)
+2. Save your New Jersey Tax ID (xxx-xxx-xxx/xxx)
+
+${taxInputComponent}
+
+---
+
+:::largeCallout{ showHeader="true" headerText="" calloutType="conditional" }
+
+- `Business Registration Certificate (BRC)|business-reg-certificate`
+- `NJ Tax ID|tax-id`
+- `Business Tax PIN|tax-pin`
+- `Certificate of Authority for Sales Tax|certificate-authority-sales-tax` (if applicable)
+
+:::

--- a/reference-data/nj-navigator/roadmaps/tasks/search-licenses.md
+++ b/reference-data/nj-navigator/roadmaps/tasks/search-licenses.md
@@ -1,0 +1,11 @@
+---
+displayname: search-licenses
+id: "search-licenses"
+urlSlug: "search-licenses"
+name: "Search Licenses"
+callToActionLink: "https://business.nj.gov/licensing-and-certification-guide"
+callToActionText: "Search Licenses"
+summaryDescriptionMd: >-
+  You can search for licenses and apply to any that are relevant to your industry. Some businesses do not
+  require a specific state license unless they sell a regulated product or service.
+---

--- a/reference-data/nj-navigator/roadmaps/tasks/site-inspection.md
+++ b/reference-data/nj-navigator/roadmaps/tasks/site-inspection.md
@@ -1,0 +1,30 @@
+---
+id: board-inspection
+webflowId: 69b02de3918235e8e9133e80
+urlSlug: site-inspection
+name: Pass Your Cosmetology Site Inspection
+displayname: site-inspection
+webflowName: Cosmetology Site Inspection
+filename: site-inspection
+summaryDescriptionMd: >-
+  After the Division of Consumer Affairs receives and confirms all materials are
+  submitted for your shop license, you need to have the site inspected.
+
+
+  To complete your requirements as a cosmetology business, an inspector from the
+  New Jersey Division's Enforcement Bureau will visit the shop location to
+  determine compliance. Read the [cosmetology shop
+  regulations](https://www.njconsumeraffairs.gov/regulations/Chapter-28-Board-of-Cosmetology-and-Hairstyling.pdf)
+  to make sure you are prepared. The Board of Cosmetology and Hairstyling will
+  contact your shop to schedule an inspection after your shop license
+  application is complete.
+callToActionLink: ""
+callToActionText: ""
+syncToWebflow: true
+---
+
+:::largeCallout{ showHeader="true" headerText="" calloutType="conditional" }
+
+A cosmetology shop license.
+
+:::

--- a/reference-data/nj-navigator/shared-types/fetchTaskByFilename.ts
+++ b/reference-data/nj-navigator/shared-types/fetchTaskByFilename.ts
@@ -1,0 +1,77 @@
+import { convertTaskMd } from "@businessnjgovnavigator/shared";
+import { Task, TaskDependencies, TaskLink } from "@businessnjgovnavigator/shared/types";
+
+export const fetchTaskByFilename = async (filename: string): Promise<Task> => {
+  const taskWithoutLinks = convertTaskMd(await fetchTaskFile(filename));
+
+  const dependencies = await fetchDependenciesFile();
+
+  const currentTaskDependencies = dependencies.find((dependency) => {
+    return dependency.task === filename || dependency.licenseTask === filename;
+  });
+  const taskDependencies = currentTaskDependencies?.taskDependencies || [];
+  const licenseTaskDependencies = currentTaskDependencies?.licenseTaskDependencies || [];
+  const combinedDependencies = [...taskDependencies, ...licenseTaskDependencies];
+  const mappedDependencies = combinedDependencies.map(fetchTaskLinkByFilename);
+
+  const unlockedByTaskLinks = await Promise.all(mappedDependencies);
+
+  return {
+    ...taskWithoutLinks,
+    unlockedBy: unlockedByTaskLinks,
+    filename: filename,
+  };
+};
+
+export const fetchTaskLinkByFilename = async (filename: string): Promise<TaskLink> => {
+  const taskWithoutLinks = convertTaskMd(await fetchTaskFile(filename));
+  return {
+    name: taskWithoutLinks.name,
+    urlSlug: taskWithoutLinks.urlSlug,
+    filename: filename,
+    id: taskWithoutLinks.id,
+  };
+};
+
+const fetchDependenciesFile = async (): Promise<TaskDependencies[]> => {
+  const file = await (process.env.NODE_ENV === "test"
+    ? import(`@/lib/roadmap/fixtures/task-dependencies.json`)
+    : import(`@businessnjgovnavigator/content/roadmaps/task-dependencies.json`));
+  return file.default.dependencies;
+};
+
+// refactor needed
+const fetchTaskFile = async (filename: string): Promise<string> => {
+  let file;
+
+  if (process.env.NODE_ENV === "test") {
+    file = await import(`@/lib/roadmap/fixtures/tasks/${filename}.md`);
+  } else {
+    try {
+      file = await import(`@businessnjgovnavigator/content/roadmaps/tasks/${filename}.md`);
+    } catch {
+      try {
+        file = await import(
+          `@businessnjgovnavigator/content/roadmaps/license-tasks/${filename}.md`
+        );
+      } catch {
+        try {
+          file = await import(
+            `@businessnjgovnavigator/content/roadmaps/municipal-tasks/${filename}.md`
+          );
+        } catch {
+          try {
+            file = await import(
+              `@businessnjgovnavigator/content/roadmaps/raffle-bingo-steps/${filename}.md`
+            );
+          } catch {
+            file = await import(
+              `@businessnjgovnavigator/content/roadmaps/env-tasks/${filename}.md`
+            );
+          }
+        }
+      }
+    }
+  }
+  return file.default;
+};

--- a/reference-data/nj-navigator/shared-types/industry.ts
+++ b/reference-data/nj-navigator/shared-types/industry.ts
@@ -1,0 +1,119 @@
+import { orderBy } from "lodash";
+import industryJson from "../../content/lib/industry.json";
+
+export interface Industry {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly licenseType?: string;
+  readonly canHavePermanentLocation: boolean;
+  readonly additionalSearchTerms?: string;
+  readonly defaultSectorId?: string;
+  readonly webflowId?: string;
+  readonly roadmapSteps: AddOn[];
+  readonly nonEssentialQuestionsIds: string[];
+  readonly modifications?: TaskModification[];
+  readonly naicsCodes?: string;
+  readonly isEnabled: boolean;
+  readonly industryOnboardingQuestions: IndustryOnboardingQuestions;
+}
+
+interface IndustryOnboardingQuestions {
+  readonly isProvidesStaffingServicesApplicable?: boolean;
+  readonly isCertifiedInteriorDesignerApplicable?: boolean;
+  readonly isRealEstateAppraisalManagementApplicable?: boolean;
+  readonly isLiquorLicenseApplicable?: boolean;
+  readonly isCpaRequiredApplicable?: boolean;
+  readonly canBeHomeBased?: boolean;
+  readonly isTransportation?: boolean;
+  readonly isCarServiceApplicable?: boolean;
+  readonly isInterstateLogisticsApplicable?: boolean;
+  readonly isInterstateMovingApplicable?: boolean;
+  readonly isChildcareForSixOrMore?: boolean;
+  readonly willSellPetCareItems?: boolean;
+  readonly isPetCareHousingApplicable?: boolean;
+  readonly isCannabisLicenseTypeApplicable?: boolean;
+  readonly isConstructionTypeApplicable?: boolean;
+  readonly isEmploymentAndPersonnelTypeApplicable?: boolean;
+  readonly whatIsPropertyLeaseType?: boolean;
+  readonly canHaveThreeOrMoreRentalUnits?: boolean;
+}
+
+export interface AddOn {
+  readonly step: number;
+  readonly weight: number;
+  readonly task?: string;
+  readonly licenseTask?: string;
+}
+
+export interface TaskModification {
+  readonly taskToReplaceFilename: string;
+  readonly replaceWithFilename: string;
+}
+
+export const LookupIndustryById = (id: string | undefined): Industry => {
+  return (
+    getIndustries().find((x) => {
+      return x.id === id;
+    }) ?? {
+      id: "",
+      name: "",
+      description: "",
+      canHavePermanentLocation: true,
+      roadmapSteps: [],
+      nonEssentialQuestionsIds: [],
+      naicsCodes: "",
+      webflowId: "",
+      isEnabled: false,
+      industryOnboardingQuestions: {
+        isProvidesStaffingServicesApplicable: undefined,
+        isCertifiedInteriorDesignerApplicable: undefined,
+        isRealEstateAppraisalManagementApplicable: undefined,
+        canBeHomeBased: undefined,
+        isLiquorLicenseApplicable: undefined,
+        isCpaRequiredApplicable: undefined,
+        isTransportation: undefined,
+        isCarServiceApplicable: undefined,
+        isInterstateLogisticsApplicable: undefined,
+        isInterstateMovingApplicable: undefined,
+        isChildcareForSixOrMore: undefined,
+        willSellPetCareItems: undefined,
+        isPetCareHousingApplicable: undefined,
+      },
+    }
+  );
+};
+
+export const isIndustryIdGeneric = (industry: Industry): boolean => {
+  return industry.id === "generic";
+};
+
+export const findIndustryByNaicsCode = (naicsCode: string): Industry | undefined => {
+  if (!naicsCode) return undefined;
+
+  const matches = getIndustries().filter((industry) => {
+    if (isIndustryIdGeneric(industry)) return false;
+    const codes =
+      industry.naicsCodes
+        ?.replace(/\s/g, "")
+        .split(",")
+        .filter((code) => code.length > 0) ?? [];
+    return codes.includes(naicsCode);
+  });
+
+  return matches.length === 1 ? matches[0] : undefined;
+};
+
+// eslint-disable-next-line unicorn/prevent-abbreviations
+export const getIndustries = (props?: { overrideShowDisabledIndustries?: boolean }): Industry[] =>
+  orderBy(
+    industryJson.industries as Industry[],
+    [isIndustryIdGeneric, "name"],
+    ["desc", "asc"],
+  ).filter((x) => {
+    return (
+      x.isEnabled ||
+      props?.overrideShowDisabledIndustries ||
+      process.env.SHOW_DISABLED_INDUSTRIES === "true"
+    );
+  });

--- a/reference-data/nj-navigator/shared-types/loadTasks.ts
+++ b/reference-data/nj-navigator/shared-types/loadTasks.ts
@@ -1,0 +1,218 @@
+import fs from "fs";
+import path from "path";
+import { convertTaskMd } from "../markdownReader";
+import { Task, TaskDependencies, TaskLink, TaskWithoutLinks } from "../types/types";
+import { getFileNameByUrlSlug, loadUrlSlugByFilename } from "./helpers";
+
+type PathParameters<P> = { params: P; locale?: string };
+export type TaskUrlSlugParameter = {
+  taskUrlSlug: string;
+};
+
+const getRoadmapsDirectory = (isTest: boolean = false): string => {
+  if (isTest) {
+    return path.join(process.cwd(), "content", "src", "roadmaps");
+  }
+  return path.join(process.cwd(), "..", "content", "src", "roadmaps");
+};
+
+const getTasksDirectory = (isTest: boolean = false): string =>
+  path.join(getRoadmapsDirectory(isTest), "tasks");
+const getLicenseDirectory = (isTest: boolean = false): string =>
+  path.join(getRoadmapsDirectory(isTest), "license-tasks");
+const getMunicipalDirectory = (isTest: boolean = false): string =>
+  path.join(getRoadmapsDirectory(isTest), "municipal-tasks");
+const getRaffleBingoStepsDirectory = (isTest: boolean = false): string =>
+  path.join(getRoadmapsDirectory(isTest), "raffle-bingo-steps");
+const getEnvironmentDirectory = (isTest: boolean = false): string =>
+  path.join(getRoadmapsDirectory(isTest), "env-tasks");
+
+export const loadAllTaskUrlSlugs = (): PathParameters<TaskUrlSlugParameter>[] => {
+  const taskFileNames = fs.readdirSync(getTasksDirectory());
+  const licenseFileNames = fs.readdirSync(getLicenseDirectory());
+  const municipalFileNames = fs.readdirSync(getMunicipalDirectory());
+  const raffleBingoFileNames = fs.readdirSync(getRaffleBingoStepsDirectory());
+  const environmentFileNames = fs.readdirSync(getEnvironmentDirectory());
+
+  return [
+    ...taskFileNames.map((fileName) => ({
+      params: {
+        taskUrlSlug: loadUrlSlugByFilename(fileName, getTasksDirectory()),
+      },
+    })),
+    ...licenseFileNames.map((fileName) => ({
+      params: {
+        taskUrlSlug: loadUrlSlugByFilename(fileName, getLicenseDirectory()),
+      },
+    })),
+    ...municipalFileNames.map((fileName) => ({
+      params: {
+        taskUrlSlug: loadUrlSlugByFilename(fileName, getMunicipalDirectory()),
+      },
+    })),
+    ...raffleBingoFileNames.map((fileName) => ({
+      params: {
+        taskUrlSlug: loadUrlSlugByFilename(fileName, getRaffleBingoStepsDirectory()),
+      },
+    })),
+    ...environmentFileNames.map((fileName) => ({
+      params: {
+        taskUrlSlug: loadUrlSlugByFilename(fileName, getEnvironmentDirectory()),
+      },
+    })),
+  ];
+};
+
+export const loadAllTasks = (isTest: boolean = false): Task[] => {
+  const taskFileNames = fs.readdirSync(getTasksDirectory(isTest));
+  const licenseFileNames = fs.readdirSync(getLicenseDirectory(isTest));
+  const municipalFileNames = fs.readdirSync(getMunicipalDirectory(isTest));
+  const raffleBingoFileNames = fs.readdirSync(getRaffleBingoStepsDirectory(isTest));
+  const environmentFileNames = fs.readdirSync(getEnvironmentDirectory(isTest));
+
+  return [
+    ...taskFileNames.map((fileName) =>
+      loadTaskByFileName(fileName, getTasksDirectory(isTest), isTest),
+    ),
+    ...licenseFileNames.map((fileName) =>
+      loadTaskByFileName(fileName, getLicenseDirectory(isTest), isTest),
+    ),
+    ...municipalFileNames.map((fileName) =>
+      loadTaskByFileName(fileName, getMunicipalDirectory(isTest), isTest),
+    ),
+    ...raffleBingoFileNames.map((fileName) =>
+      loadTaskByFileName(fileName, getRaffleBingoStepsDirectory(isTest), isTest),
+    ),
+    ...environmentFileNames.map((fileName) =>
+      loadTaskByFileName(fileName, getEnvironmentDirectory(isTest), isTest),
+    ),
+  ];
+};
+
+export const loadAllLicenseTasks = (): Task[] => {
+  const licenseFileNames = fs.readdirSync(getLicenseDirectory());
+  return licenseFileNames.map((fileName) => loadTaskByFileName(fileName, getLicenseDirectory()));
+};
+
+export const loadAllRaffleBingoSteps = (): Task[] => {
+  const licenseFileNames = fs.readdirSync(getLicenseDirectory());
+  return licenseFileNames.map((fileName) => loadTaskByFileName(fileName, getLicenseDirectory()));
+};
+
+export const loadAllMunicipalTasks = (): Task[] => {
+  const municipalFileNames = fs.readdirSync(getMunicipalDirectory());
+  return municipalFileNames.map((fileName) =>
+    loadTaskByFileName(fileName, getMunicipalDirectory()),
+  );
+};
+
+export const loadAllEnvironmentTasks = (): Task[] => {
+  const environmentFileNames = fs.readdirSync(getEnvironmentDirectory());
+  return environmentFileNames.map((fileName) =>
+    loadTaskByFileName(fileName, getEnvironmentDirectory()),
+  );
+};
+
+export const loadAllTasksOnly = (): Task[] => {
+  const taskFileNames = fs.readdirSync(getTasksDirectory());
+  return taskFileNames.map((fileName) => loadTaskByFileName(fileName, getTasksDirectory()));
+};
+
+export const loadTaskByUrlSlug = (urlSlug: string): Task => {
+  try {
+    const fileAsTask = getFileNameByUrlSlug(getTasksDirectory(), urlSlug);
+    return loadTaskByFileName(fileAsTask, getTasksDirectory());
+  } catch {
+    try {
+      const fileAsLicense = getFileNameByUrlSlug(getLicenseDirectory(), urlSlug);
+      return loadTaskByFileName(fileAsLicense, getLicenseDirectory());
+    } catch {
+      try {
+        const fileAsMunicipal = getFileNameByUrlSlug(getMunicipalDirectory(), urlSlug);
+        return loadTaskByFileName(fileAsMunicipal, getMunicipalDirectory());
+      } catch {
+        try {
+          const fileAsRaffleBingo = getFileNameByUrlSlug(getRaffleBingoStepsDirectory(), urlSlug);
+          return loadTaskByFileName(fileAsRaffleBingo, getRaffleBingoStepsDirectory());
+        } catch {
+          const fileAsEnvironment = getFileNameByUrlSlug(getEnvironmentDirectory(), urlSlug);
+          return loadTaskByFileName(fileAsEnvironment, getEnvironmentDirectory());
+        }
+      }
+    }
+  }
+};
+
+export const loadTaskByFileName = (
+  fileName: string,
+  directory: string,
+  isTest: boolean = false,
+): Task => {
+  const fullPath = path.join(directory, `${fileName}`);
+  const fileContents = fs.readFileSync(fullPath, "utf8");
+
+  const dependencies = JSON.parse(
+    fs.readFileSync(path.join(getRoadmapsDirectory(isTest), "task-dependencies.json"), "utf8"),
+  ).dependencies as TaskDependencies[];
+
+  const taskWithoutLinks = convertTaskMd(fileContents);
+  const fileNameWithoutMd = fileName.split(".md")[0];
+
+  const currentTaskDependencies = dependencies.find((dependency) => {
+    return dependency.task === fileNameWithoutMd || dependency.licenseTask === fileNameWithoutMd;
+  });
+  const taskDependencies = currentTaskDependencies?.taskDependencies || [];
+  const licenseTaskDependencies = currentTaskDependencies?.licenseTaskDependencies || [];
+  const combinedDependencies = [...taskDependencies, ...licenseTaskDependencies];
+  const unlockedByTaskLinks = combinedDependencies.map((dependencyFileName) => {
+    return loadTaskLinkByFilename(dependencyFileName, isTest);
+  });
+
+  return {
+    ...taskWithoutLinks,
+    unlockedBy: unlockedByTaskLinks,
+    filename: fileNameWithoutMd,
+  } as Task;
+};
+
+const loadTaskLinkByFilename = (fileName: string, isTest: boolean = false): TaskLink => {
+  let fileContents;
+  try {
+    fileContents = fs.readFileSync(path.join(getTasksDirectory(isTest), `${fileName}.md`), "utf8");
+  } catch {
+    try {
+      fileContents = fs.readFileSync(
+        path.join(getLicenseDirectory(isTest), `${fileName}.md`),
+        "utf8",
+      );
+    } catch {
+      try {
+        fileContents = fs.readFileSync(
+          path.join(getMunicipalDirectory(isTest), `${fileName}.md`),
+          "utf8",
+        );
+      } catch {
+        try {
+          fileContents = fs.readFileSync(
+            path.join(getRaffleBingoStepsDirectory(isTest), `${fileName}.md`),
+            "utf8",
+          );
+        } catch {
+          fileContents = fs.readFileSync(
+            path.join(getEnvironmentDirectory(isTest), `${fileName}.md`),
+            "utf8",
+          );
+        }
+      }
+    }
+  }
+
+  const taskWithoutLinks = convertTaskMd(fileContents) as TaskWithoutLinks;
+
+  return {
+    name: taskWithoutLinks.name,
+    urlSlug: taskWithoutLinks.urlSlug,
+    filename: fileName,
+    id: taskWithoutLinks.id,
+  };
+};

--- a/reference-data/nj-navigator/shared-types/roadmapBuilder.ts
+++ b/reference-data/nj-navigator/shared-types/roadmapBuilder.ts
@@ -1,0 +1,272 @@
+import { fetchTaskByFilename } from "@/lib/async-content-fetchers/fetchTaskByFilename";
+import { SectionType } from "@businessnjgovnavigator/shared";
+import { IndustryRoadmap, Roadmap } from "@businessnjgovnavigator/shared/types";
+
+export const buildRoadmap = async ({
+  industryId,
+  addOns,
+}: {
+  industryId: string | undefined;
+  addOns: string[];
+}): Promise<Roadmap> => {
+  let stepImporter: () => Promise<GenericStep[]>;
+
+  if (industryId) {
+    stepImporter =
+      industryId === "domestic-employer" ? importDomesticEmployerSteps : importGenericSteps;
+  } else {
+    stepImporter = importForeignSteps;
+  }
+
+  const results = await stepImporter();
+
+  let roadmapBuilder: RoadmapBuilder = {
+    steps: results.map((step: GenericStep) => {
+      return { ...step };
+    }),
+    tasks: [],
+  };
+
+  roadmapBuilder = await (industryId
+    ? generateIndustryRoadmap(roadmapBuilder, industryId, addOns)
+    : applyAddOns(roadmapBuilder, addOns));
+
+  while (hasSteps(roadmapBuilder) && lastStepHasNoTasks(roadmapBuilder)) {
+    roadmapBuilder = removeLastStep(roadmapBuilder);
+  }
+  roadmapBuilder = removeDuplicateTasks(roadmapBuilder);
+  return convertToRoadmap(roadmapBuilder);
+};
+
+const generateIndustryRoadmap = async (
+  builder: RoadmapBuilder,
+  industryId: string,
+  addOns: string[],
+): Promise<RoadmapBuilder> => {
+  const industryRoadmap: IndustryRoadmap = await importRoadmap(industryId);
+
+  addTasksFromAddOn(builder, industryRoadmap.roadmapSteps);
+  await applyAddOns(builder, [...addOns]);
+  modifyTasks(builder, industryRoadmap.modifications);
+
+  return builder;
+};
+
+const applyAddOns = async (
+  builder: RoadmapBuilder,
+  addOnFilenames: string[],
+): Promise<RoadmapBuilder> => {
+  for (const addOnFilename of addOnFilenames) {
+    const addOns = await importAddOn(addOnFilename);
+    addTasksFromAddOn(builder, addOns.roadmapSteps);
+    modifyTasks(builder, addOns.modifications);
+  }
+
+  return builder;
+};
+
+const importRoadmap = async (industryId: string): Promise<IndustryRoadmap> => {
+  if (process.env.NODE_ENV === "test") {
+    const industries = await import(`@/lib/roadmap/fixtures/industries/${industryId}.json`);
+    return industries.default as IndustryRoadmap;
+  }
+  const industries = await import(
+    `@businessnjgovnavigator/content/roadmaps/industries/${industryId}.json`
+  );
+  return industries.default as IndustryRoadmap;
+};
+
+const importDomesticEmployerSteps = async (): Promise<GenericStep[]> => {
+  if (process.env.NODE_ENV === "test") {
+    const steps = await import(`@/lib/roadmap/fixtures/steps-domestic-employer.json`);
+    return steps.steps as GenericStep[];
+  }
+
+  const steps = await import(
+    `@businessnjgovnavigator/content/roadmaps/steps-domestic-employer.json`
+  );
+  return steps.steps as GenericStep[];
+};
+
+const importGenericSteps = async (): Promise<GenericStep[]> => {
+  if (process.env.NODE_ENV === "test") {
+    const steps = await import(`@/lib/roadmap/fixtures/steps.json`);
+    return steps.steps as GenericStep[];
+  }
+
+  const steps = await import(`@businessnjgovnavigator/content/roadmaps/steps.json`);
+  return steps.steps as GenericStep[];
+};
+
+const importForeignSteps = async (): Promise<GenericStep[]> => {
+  if (process.env.NODE_ENV === "test") {
+    const steps = await import(`@/lib/roadmap/fixtures/steps-foreign.json`);
+    return steps.steps as GenericStep[];
+  }
+
+  const steps = await import(`@businessnjgovnavigator/content/roadmaps/steps-foreign.json`);
+  return steps.steps as GenericStep[];
+};
+
+const importAddOn = async (relativePath: string): Promise<IndustryRoadmap> => {
+  if (process.env.NODE_ENV === "test") {
+    return (await import(`@/lib/roadmap/fixtures/add-ons/${relativePath}.json`)) as IndustryRoadmap;
+  }
+
+  return (await import(
+    `@businessnjgovnavigator/content/roadmaps/add-ons/${relativePath}.json`
+  )) as IndustryRoadmap;
+};
+
+const orderByWeight = (taskA: TaskBuilder, taskB: TaskBuilder): number => {
+  if (taskA.stepNumber === taskB.stepNumber) {
+    return taskA.weight > taskB.weight ? 1 : -1;
+  } else if (taskA.stepNumber > taskB.stepNumber) {
+    return 1;
+  } else {
+    return -1;
+  }
+};
+
+const addTasksFromAddOn = (builder: RoadmapBuilder, addOns: AddOn[]): RoadmapBuilder => {
+  for (const addOn of addOns) {
+    const task = addOn.task || addOn.licenseTask;
+    if (!task) continue;
+    builder.tasks = [
+      ...builder.tasks,
+      { filename: task, weight: addOn.weight, stepNumber: addOn.step, required: !!addOn.required },
+    ];
+  }
+
+  return builder;
+};
+
+const modifyTasks = (
+  roadmap: RoadmapBuilder,
+  modifications: TaskModification[],
+): RoadmapBuilder => {
+  if (modifications) {
+    for (const modification of modifications) {
+      const task = findTaskInRoadmapByFilename(roadmap, modification.taskToReplaceFilename);
+      if (!task) {
+        continue;
+      }
+      task.filename = modification.replaceWithFilename;
+    }
+  }
+
+  return roadmap;
+};
+
+const removeDuplicateTasks = (roadmap: RoadmapBuilder): RoadmapBuilder => {
+  const taskNames: string[] = [];
+  roadmap.tasks = roadmap.tasks.filter((task) => {
+    if (taskNames.includes(task.filename)) {
+      return false;
+    }
+    taskNames.push(task.filename);
+    return true;
+  });
+  return roadmap;
+};
+
+const findTaskInRoadmapByFilename = (
+  roadmapBuilder: RoadmapBuilder,
+  taskFilename: string,
+): TaskBuilder | undefined => {
+  return roadmapBuilder.tasks.find((task) => {
+    return task.filename === taskFilename;
+  });
+};
+
+const convertToRoadmap = async (roadmapBuilder: RoadmapBuilder): Promise<Roadmap> => {
+  const roadmap = {
+    steps: roadmapBuilder.steps,
+    tasks: await Promise.all(
+      roadmapBuilder.tasks.sort(orderByWeight).map(async (task: TaskBuilder) => {
+        return {
+          ...(await fetchTaskByFilename(task.filename)),
+          stepNumber: task.stepNumber,
+          required: task.required,
+        };
+      }),
+    ),
+  };
+
+  const allFilenames = new Set(
+    roadmap.tasks.map((task) => {
+      return task.filename;
+    }),
+  );
+
+  return {
+    ...roadmap,
+    tasks: roadmap.tasks.map((task) => {
+      return {
+        ...task,
+        unlockedBy: task.unlockedBy.filter((it) => {
+          return allFilenames.has(it.filename);
+        }),
+      };
+    }),
+  };
+};
+
+const hasSteps = (roadmap: RoadmapBuilder): boolean => {
+  return roadmap.steps.length > 0;
+};
+
+const lastStepHasNoTasks = (roadmap: RoadmapBuilder): boolean => {
+  const lastStepNumber = roadmap.steps[roadmap.steps.length - 1].stepNumber;
+  return roadmap.tasks.every((task) => {
+    return task.stepNumber !== lastStepNumber;
+  });
+};
+
+const removeLastStep = (roadmapBuilder: RoadmapBuilder): RoadmapBuilder => {
+  roadmapBuilder.steps = roadmapBuilder.steps.splice(0, roadmapBuilder.steps.length - 1);
+  return roadmapBuilder;
+};
+
+interface RoadmapBuilder {
+  steps: StepBuilder[];
+  tasks: TaskBuilder[];
+}
+
+interface StepBuilder {
+  stepNumber: number;
+  id: string;
+  name: string;
+  timeEstimate: string;
+  section: SectionType;
+  description: string;
+}
+
+interface TaskBuilder {
+  filename: string;
+  weight: number;
+  stepNumber: number;
+  required: boolean;
+}
+
+interface GenericStep {
+  stepNumber: number;
+  id: string;
+  name: string;
+  section: SectionType;
+  timeEstimate: string;
+  description: string;
+}
+
+export interface AddOn {
+  step: number;
+  weight: number;
+  task?: string | undefined | null;
+  licenseTask?: string | undefined | null;
+  required?: boolean;
+}
+
+export interface TaskModification {
+  taskToReplaceFilename: string;
+  replaceWithFilename: string;
+}

--- a/reference-data/nj-navigator/shared-types/types.ts
+++ b/reference-data/nj-navigator/shared-types/types.ts
@@ -1,0 +1,713 @@
+import type { Reducer } from "react";
+import { BusinessUser } from "../businessUser";
+import { getMergedConfig } from "../contexts/configContext";
+import { EmergencyTripPermitApplicationInfo } from "../emergencyTripPermit";
+import {
+  FieldsForErrorHandling,
+  FormationAddress,
+  FormationMember,
+  FormationSigner,
+} from "../formationData";
+import { AddOn, TaskModification } from "../industry";
+import { LicenseName, LicenseTaskId } from "../license";
+import { BusinessPersona, IndustrySpecificData, ProfileData } from "../profileData";
+import { SectionType, UserData } from "../userData";
+
+// returns all keys in an object of a type
+// e.g. KeysOfType<Task, boolean> will give all keys in the Task that have boolean types
+export type KeysOfType<T, V> = { [K in keyof T]-?: T[K] extends V ? K : never }[keyof T];
+
+export type UserDataError = "NO_DATA" | "CACHED_ONLY" | "UPDATE_FAILED";
+
+export type ProfileError =
+  | "REQUIRED_ESSENTIAL_QUESTION"
+  | "REQUIRED_EXISTING_BUSINESS"
+  | "REQUIRED_FOREIGN_BUSINESS_TYPE"
+  | "REQUIRED_REVIEW_INFO_BELOW";
+
+export type OnboardingErrors = ProfileError;
+
+export type FlowType = Exclude<BusinessPersona, undefined>;
+
+export const createEmptyTaskWithoutLinks = (): TaskWithoutLinks => {
+  return {
+    id: "",
+    name: "",
+    urlSlug: "",
+    callToActionLink: "",
+    callToActionText: "",
+    summaryDescriptionMd: "",
+    contentMd: "",
+    required: undefined,
+    agencyId: undefined,
+    agencyAdditionalContext: undefined,
+    formName: undefined,
+  };
+};
+
+export const createEmptyDbaDisplayContent = (): FormationDbaContent => {
+  return {
+    Authorize: createEmptyTaskWithoutLinks(),
+    DbaResolution: createEmptyTaskWithoutLinks(),
+    Formation: createEmptyTaskWithoutLinks(),
+  };
+};
+
+export const createEmptyTaskDisplayContent = (): FormationDbaDisplayContent => {
+  return {
+    formationDbaContent: createEmptyDbaDisplayContent(),
+  };
+};
+
+export type OnboardingStatus = "SUCCESS" | "ERROR";
+
+export type FormationStepNames = "Name" | "Business" | "Contacts" | "Billing" | "Review";
+export type DbaStepNames = "Business Name" | "DBA Resolution" | "Authorize Business";
+export type EmergencyTripPermitStepNames =
+  | "Instructions"
+  | "Requestor"
+  | "Trip"
+  | "Billing"
+  | "Review";
+
+export type FormationFieldErrorState = {
+  field: FieldsForErrorHandling;
+  hasError: boolean;
+  label: string;
+};
+
+export const profileFieldsFromConfig = getMergedConfig().profileDefaults.fields;
+
+export type RoadmapDisplayContent = {
+  sidebarDisplayContent: Record<string, SidebarCardContent>;
+};
+
+export const defaultDisplayDateFormat = "MM/DD/YYYY";
+export const defaultMarkdownDateFormat = "MM/DD/YYYY";
+
+export type FundingCertifications =
+  | "woman-owned"
+  | "minority-owned"
+  | "veteran-owned"
+  | "disabled-veteran"
+  | "small-business-enterprise"
+  | "disadvantaged-business-enterprise"
+  | "emerging-small-business-enterprise";
+
+export type Funding = {
+  id: string;
+  filename: string;
+  name: string;
+  urlSlug: string;
+  callToActionLink: string;
+  callToActionText: string;
+  sidebarCardBodyText: string;
+  summaryDescriptionMd: string;
+  contentMd: string;
+  fundingType: FundingType;
+  agency: string[] | null | undefined;
+  publishStageArchive: FundingPublishStatus | null;
+  openDate: string;
+  dueDate: string;
+  status: FundingStatus;
+  programFrequency: FundingProgramFrequency;
+  businessStage: FundingBusinessStage;
+  employeesRequired: string;
+  homeBased: FundingHomeBased;
+  certifications: FundingCertifications[] | null;
+  preferenceForOpportunityZone: FundingpreferenceForOpportunityZone | null;
+  county: County[];
+  sector: string[];
+  programPurpose: string | null | undefined;
+  agencyContact: string | null | undefined;
+  isNonprofitOnly: boolean | undefined | null;
+  minEmployeesRequired: number | undefined;
+  maxEmployeesRequired: number | undefined;
+  priority: boolean | undefined;
+};
+
+export type Certification = {
+  id: string;
+  filename: string;
+  name: string;
+  urlSlug: string;
+  summaryDescriptionMd: string;
+  contentMd: string;
+  sidebarCardBodyText: string;
+  callToActionLink: string | undefined;
+  callToActionText: string | undefined;
+  agency: string[] | null | undefined;
+  applicableOwnershipTypes: string[] | null | undefined;
+  isSbe: boolean;
+};
+
+export interface Opportunity {
+  id: string;
+  name: string;
+  urlSlug: string;
+  contentMd: string;
+  sidebarCardBodyText: string;
+  dueDate?: string;
+  status?: string;
+}
+
+interface AnytimeAction {
+  name: string;
+  filename: string;
+  type: string;
+  synonyms?: string[];
+}
+
+export interface AnytimeActionTask extends AnytimeAction {
+  id: string;
+  category: AnytimeActionCategory[];
+  urlSlug: string;
+  callToActionLink?: string;
+  callToActionText?: string;
+  issuingAgency?: string;
+  moveToRecommendedForYouSection?: boolean;
+  industryIds: string[];
+  sectorIds: string[];
+  applyToAllUsers: boolean;
+  summaryDescriptionMd: string;
+  contentMd: string;
+  description?: string;
+  searchMetaDataMatch?: string;
+}
+
+export interface AnytimeActionCategory {
+  categoryId: string;
+  categoryName: string;
+}
+
+export interface AnytimeActionCategoryMapping {
+  [key: string]: string;
+}
+
+export interface AnytimeActionLicenseReinstatement extends AnytimeAction {
+  licenseName: LicenseName;
+  urlSlug: string;
+  contentMd: string;
+  callToActionLink: string | undefined;
+  callToActionText: string | undefined;
+  issuingAgency: string;
+  summaryDescriptionMd: string;
+  description?: string;
+  searchMetaDataMatch?: string;
+  category: AnytimeActionCategory[];
+}
+
+export type FundingType =
+  | "tax credit"
+  | "loan"
+  | "grant"
+  | "technical assistance"
+  | "hiring and employee training support"
+  | "tax exemption";
+export type FundingPublishStatus = "Do Not Publish";
+export type FundingStatus =
+  | "rolling application"
+  | "deadline"
+  | "first come, first serve"
+  | "closed"
+  | "opening soon";
+export const FundingStatusOrder: Record<FundingStatus, number> = {
+  "rolling application": 2,
+  deadline: 0,
+  "first come, first serve": 1,
+  closed: 4,
+  "opening soon": 4,
+};
+export type FundingProgramFrequency =
+  | "annual"
+  | "ongoing"
+  | "reoccuring"
+  | "one-time"
+  | "pilot"
+  | "other";
+export type FundingBusinessStage = "early-stage" | "operating" | "both";
+export type FundingHomeBased = "yes" | "no" | "unknown";
+export type FundingpreferenceForOpportunityZone = "yes" | "no";
+
+export const AllCounties = [
+  "All",
+  "Atlantic",
+  "Bergen",
+  "Burlington",
+  "Camden",
+  "Cape May",
+  "Cumberland",
+  "Essex",
+  "Gloucester",
+  "Hudson",
+  "Hunterdon",
+  "Mercer",
+  "Middlesex",
+  "Monmouth",
+  "Morris",
+  "Ocean",
+  "Passaic",
+  "Salem",
+  "Somerset",
+  "Sussex",
+  "Union",
+  "Warren",
+];
+
+export type County =
+  | "All"
+  | "Atlantic"
+  | "Bergen"
+  | "Burlington"
+  | "Camden"
+  | "Cape May"
+  | "Cumberland"
+  | "Essex"
+  | "Gloucester"
+  | "Hudson"
+  | "Hunterdon"
+  | "Mercer"
+  | "Middlesex"
+  | "Monmouth"
+  | "Morris"
+  | "Ocean"
+  | "Passaic"
+  | "Salem"
+  | "Somerset"
+  | "Sussex"
+  | "Union"
+  | "Warren";
+
+export interface FormationSignedAddress
+  extends FormationMember, Partial<Omit<FormationSigner, "name">> {}
+
+export type FormationDbaContent = {
+  DbaResolution: TaskWithoutLinks;
+  Authorize: TaskWithoutLinks;
+  Formation: TaskWithoutLinks;
+};
+export type FormationDbaDisplayContent = {
+  formationDbaContent: FormationDbaContent;
+};
+
+export interface Roadmap {
+  steps: Step[];
+  tasks: Task[];
+}
+
+export interface Step {
+  stepNumber: number;
+  name: string;
+  timeEstimate: string;
+  description: string;
+  section: SectionType;
+}
+
+export interface Task {
+  id: string;
+  displayname?: string;
+  filename: string;
+  stepNumber?: number;
+  name: string;
+  urlSlug: string;
+  callToActionLink: string;
+  callToActionText: string;
+  contentMd: string;
+  summaryDescriptionMd: string;
+  unlockedBy: TaskLink[];
+  required?: boolean;
+  agencyId?: string;
+  agencyAdditionalContext?: string;
+  formName?: string;
+  hidden?: true;
+  requiresLocation?: boolean;
+  industryId?: string;
+  stepLabel?: string;
+}
+
+export interface TaskWithLicenseTaskId extends Task {
+  id: LicenseTaskId;
+  licenseName?: LicenseName;
+}
+
+export interface WebflowLicense {
+  id: string;
+  webflowId: string;
+  filename: string;
+  urlSlug?: string;
+  webflowName?: string;
+  callToActionLink?: string;
+  callToActionText?: string;
+  agencyId?: string;
+  agencyAdditionalContext?: string;
+  divisionPhone?: string;
+  licenseCertificationClassification?: string;
+  webflowIndustry?: string;
+  contentMd?: string;
+  summaryDescriptionMd: string;
+}
+
+export interface TaskLink {
+  name: string;
+  id: string;
+  urlSlug: string;
+  filename: string;
+}
+
+export type TaskDependencies = {
+  task?: string;
+  licenseTask?: string;
+  taskDependencies?: string[];
+  licenseTaskDependencies?: string[];
+};
+
+export const taxFilingMethod = [
+  "online",
+  "paper-or-by-mail-only",
+  "online-required",
+  "online-or-phone",
+] as const;
+export type TaxFilingMethod = (typeof taxFilingMethod)[number];
+
+export type TaxAgency =
+  | "New Jersey Division of Taxation"
+  | "Internal Revenue Service (IRS)"
+  | "NJ Department of Labor"
+  | "New Jersey Division of Revenue and Enterprise Services";
+
+export interface Filing {
+  id: string;
+  filename: string;
+  name: string;
+  urlSlug: string;
+  callToActionLink?: string;
+  callToActionText?: string;
+  contentMd: string;
+  summaryDescriptionMd: string;
+  treasuryLink?: string;
+  additionalInfo?: string;
+  frequency?: string;
+  extension?: boolean;
+  taxRates?: string;
+  filingMethod?: TaxFilingMethod | null;
+  filingDetails?: string;
+  agency?: TaxAgency | null;
+}
+
+export interface LicenseEventType {
+  issuingAgency: string;
+  disclaimerText: string;
+  renewalEventDisplayName: string;
+  expirationEventDisplayName: string;
+  filename: string;
+  urlSlug: string;
+  callToActionLink?: string;
+  callToActionText?: string;
+  contentMd: string;
+  summaryDescriptionMd?: string;
+  licenseName: LicenseName;
+}
+
+export interface XrayRenewalCalendarEventType {
+  issuingAgency: string;
+  eventDisplayName: string;
+  filename: string;
+  urlSlug: string;
+  callToActionLink?: string;
+  callToActionText?: string;
+  contentMd: string;
+  summaryDescriptionMd?: string;
+  name: string;
+  id: string;
+}
+
+export type OperateReference = {
+  name: string;
+  urlSlug: string;
+  urlPath: string;
+};
+
+export interface CallToActionHyperlink {
+  text: string;
+  destination: string;
+  onClick: () => void;
+}
+
+export interface SessionHelper {
+  getCurrentToken: () => Promise<string>;
+  getCurrentUser: () => Promise<BusinessUser>;
+}
+
+export type SelfRegResponse = {
+  authRedirectURL: string;
+  userData: UserData;
+};
+
+export type SelfRegRequest = {
+  name: string;
+  email: string;
+  confirmEmail: string;
+  receiveNewsletter: boolean;
+  userTesting: boolean;
+};
+
+export type SearchBusinessNameError = "BAD_INPUT" | "SEARCH_FAILED";
+
+export type SidebarCardContent = {
+  contentMd: string;
+  id: string;
+  header?: string;
+  notStartedHeader?: string;
+  completedHeader?: string;
+  ctaText?: string;
+  preBodySpanButtonText?: string;
+  hasCloseButton: boolean;
+};
+
+export type NaicsCodeObject = {
+  SixDigitDescription?: string;
+  SixDigitCode?: number;
+  FourDigitDescription?: string;
+  FourDigitCode?: number;
+  TwoDigitDescription?: string;
+  TwoDigitCode?: number[];
+  industryIds?: string[];
+};
+
+export type LicenseSearchError = "NOT_FOUND" | "FIELDS_REQUIRED" | "SEARCH_FAILED";
+
+export type ElevatorRegistrationSearchError =
+  | CommunityAffairsSearchError
+  | "NO_ELEVATOR_REGISTRATIONS_FOUND";
+
+export type HotelMotelRegistrationSearchError =
+  | CommunityAffairsSearchError
+  | "NO_HOTEL_MOTEL_REGISTRATIONS_FOUND";
+
+export type MultipleDwellingSearchError =
+  | CommunityAffairsSearchError
+  | "NO_MULTIPLE_DWELLINGS_REGISTRATIONS_FOUND";
+
+export type CommunityAffairsSearchError =
+  | "NO_PROPERTY_INTEREST_FOUND"
+  | "FIELDS_REQUIRED"
+  | "SEARCH_FAILED";
+
+export type FeedbackRequestModalNames =
+  | "Select Feedback"
+  | "Feature Request"
+  | "Request Submitted"
+  | "Report Issue";
+
+const _profileTabs = [
+  "info",
+  "contact",
+  "permits",
+  "numbers",
+  "documents",
+  "notes",
+  "personalize",
+] as const;
+
+export type ProfileTabs = (typeof _profileTabs)[number];
+
+export const profileTabs = _profileTabs as unknown as ProfileTabs[];
+
+export type MarkdownResult = {
+  content: string;
+  grayMatter: unknown;
+};
+
+export type TaskWithoutLinks = {
+  id: string;
+  name: string;
+  urlSlug: string;
+  callToActionLink: string;
+  callToActionText: string;
+  summaryDescriptionMd: string;
+  contentMd: string;
+  required?: boolean;
+  agencyId?: string;
+  agencyAdditionalContext?: string;
+  formName?: string;
+};
+export type Page = { current: number; previous: number };
+
+export type StepperStep = { name: string; hasError?: boolean; isComplete?: boolean };
+
+export interface ContextualInfoFile extends ContextualInfo {
+  filename: string;
+}
+
+export interface FaqItem {
+  name: string;
+  slug: string;
+  body: string;
+  category?: string;
+  "sub-category"?: string;
+  webflowId?: string;
+  author?: string;
+}
+
+export interface CategoryItem {
+  name: string;
+  slug: string;
+  webflowId?: string;
+  "nav-name"?: string;
+  "description-text"?: string;
+  "navbar-order"?: number;
+  "customized-drop-down-link-filter"?: string;
+  "bg-image"?: string;
+  "topic-icon"?: string;
+  "mobile-icon"?: string;
+  "topic-icon-white-bg"?: string;
+  "topic-icon-cat-page"?: string;
+  arrow?: string;
+  "navigator-promotion-image"?: string;
+  "icon-accessibility-alt-description"?: string;
+  "topic-color"?: string;
+  "topic-description"?: string;
+  "homepage-description"?: string;
+  "nav-promo-hero-button-text"?: string;
+  "nav-promo-heading"?: string;
+  "nav-promo-description"?: string;
+  "nav-promo-button-text"?: string;
+  "navigation-promotion-color"?: string;
+  "navigation-tile-border-color"?: string;
+  "nav-promo-text-color-2"?: string;
+  "category-page-tile-background"?: string;
+  "category-page-header"?: string;
+  "category-page-promo-text"?: string;
+  "side-nav-hover-color"?: string;
+  "side-nav-background-color"?: string;
+  "side-nav-active-color"?: string;
+}
+
+export interface ActionTile {
+  imgPath: string;
+  tileText: string;
+  dataTestId: string;
+  onClick: () => void;
+  isPrimary?: boolean;
+}
+
+export type OutageAlertType = "ALL" | "UNREGISTERED_ONLY" | "LOGGED_IN_ONLY" | undefined;
+
+export type OutageConfig = {
+  FEATURE_ENABLE_OUTAGE_ALERT_BAR: boolean;
+  OUTAGE_ALERT_MESSAGE: string;
+  OUTAGE_ALERT_TYPE: OutageAlertType;
+};
+
+export interface NonEssentialQuestion {
+  id: string;
+  questionText: string;
+  addOnWhenYes?: string;
+  addOnWhenNo?: string;
+}
+
+export interface PageMetadata {
+  filename: string;
+  titlePostfix: string;
+  siteDescription: string;
+  homeTitle: string;
+  dashboardTitle: string;
+  profileTitle: string;
+  deadLinksTitle: string;
+  deadUrlsTitle: string;
+  featureFlagsTitle: string;
+}
+
+export type FieldsForAddressErrorHandling = keyof FormationAddress;
+export type AddressFields = keyof FormationAddress;
+export type AddressTextField = keyof FormationAddress;
+
+export type AddressFieldErrorState = {
+  field: FieldsForAddressErrorHandling;
+  hasError: boolean;
+  label: string;
+};
+export type FieldErrorType = undefined | unknown;
+
+export type FieldsForEmergencyTripPermitErrorHandling = keyof EmergencyTripPermitApplicationInfo;
+export type EmergencyTripPermitFieldErrorState = {
+  field: FieldsForEmergencyTripPermitErrorHandling;
+  hasError: boolean;
+  label: string;
+};
+
+export enum FieldStateActionKind {
+  RESET = "RESET",
+  REGISTER = "REGISTER",
+  UNREGISTER = "UNREGISTER",
+  VALIDATION = "VALIDATION",
+}
+
+interface ValidationAction<T, FieldError = FieldErrorType> {
+  type: FieldStateActionKind.VALIDATION;
+  payload: { field: keyof T | (keyof T)[]; invalid: boolean; errorTypes?: FieldError[] };
+}
+
+interface RegisterAction<T> {
+  type: FieldStateActionKind.REGISTER;
+  payload: { field: keyof T };
+}
+
+interface UnRegisterAction<T> {
+  type: FieldStateActionKind.UNREGISTER;
+  payload: { field: keyof T };
+}
+
+interface ResetAction {
+  type: FieldStateActionKind.RESET;
+  payload?: undefined;
+}
+
+type FormContextReducerActions<T, FieldError = FieldErrorType> =
+  | ResetAction
+  | ValidationAction<T, FieldError>
+  | RegisterAction<T>
+  | UnRegisterAction<T>;
+export type FieldStatus<FieldError = FieldErrorType> = {
+  invalid: boolean;
+  updated?: boolean;
+  errorTypes?: FieldError[];
+};
+export type ReducedFieldStates<
+  K extends string | number | symbol,
+  FieldError = FieldErrorType,
+> = Record<K, FieldStatus<FieldError>>;
+export type FormContextReducer<T, FieldError = FieldErrorType> = Reducer<
+  ReducedFieldStates<keyof T, FieldError>,
+  FormContextReducerActions<T, FieldError>
+>;
+
+export interface FormContextType<T, FieldError = FieldErrorType> {
+  fieldStates: ReducedFieldStates<keyof T, FieldError>;
+  runValidations: boolean;
+  reducer: React.Dispatch<
+    FormContextReducerActions<ReducedFieldStates<keyof T, FieldError>, FieldError>
+  >;
+}
+
+// eslint-disable-next-line unicorn/prevent-abbreviations
+export type FormContextFieldProps<K = FieldErrorType> = { errorTypes?: K[] };
+
+export type ProfileContentField = Exclude<
+  (keyof ProfileData | keyof IndustrySpecificData) & keyof typeof profileFieldsFromConfig,
+  "businessPersona"
+>;
+
+export type CMSMap = Record<string, Record<string, string>>;
+
+export interface IndustryRoadmap {
+  id: string;
+  roadmapSteps: AddOn[];
+  modifications: TaskModification[];
+}
+
+export interface ContextualInfo {
+  isVisible: boolean;
+  header: string;
+  markdown: string;
+}

--- a/reference-data/sba/SUMMARY.md
+++ b/reference-data/sba/SUMMARY.md
@@ -1,0 +1,123 @@
+# SBA 10-Step Business Startup Guide — Summary
+
+## Source
+- **URL**: https://www.sba.gov/business-guide/10-steps-start-your-business
+- **Publisher**: U.S. Small Business Administration (SBA)
+- **Last crawled**: April 2026
+- **Page publication date**: ~2023 (content is evergreen / continuously maintained)
+
+## Files Downloaded
+
+| File | Description | Size |
+|------|-------------|------|
+| `sba-10-steps.html` | Full HTML of the canonical 10-step page | ~106 KB |
+| `step-market-research-competitive-analysis.html` | Step 1 detail page | ~112 KB |
+| `step-write-your-business-plan.html` | Step 2 detail page | ~121 KB |
+| `step-fund-your-business.html` | Step 3 detail page | ~121 KB |
+| `step-pick-your-business-location.html` | Step 4 detail page | ~113 KB |
+| `step-choose-business-structure.html` | Step 5 detail page | ~121 KB |
+| `step-register-your-business.html` | Step 7 detail page | ~129 KB |
+| `step-get-federal-state-tax-id-numbers.html` | Step 8 detail page | ~121 KB |
+| `step-apply-licenses-permits.html` | Step 9 detail page | ~110 KB |
+
+Note: Steps 6 (Choose a business name) and 10 (Open a business bank account) have direct SBA sub-pages but were not separately archived; their content is summarized below.
+
+## The 10 Steps — Ordered Sequence
+
+The SBA presents these as a numbered, sequential checklist. The stated framing is:
+> "Starting a business involves planning, making key financial decisions, and completing a series of legal activities."
+
+| Step | Title | SBA Sub-page URL |
+|------|-------|------------------|
+| 1 | Conduct market research | /business-guide/plan-your-business/market-research-competitive-analysis |
+| 2 | Write your business plan | /business-guide/plan-your-business/write-your-business-plan |
+| 3 | Fund your business | /business-guide/plan-your-business/fund-your-business |
+| 4 | Pick your business location | /business-guide/launch-your-business/pick-your-business-location |
+| 5 | Choose a business structure | /business-guide/launch-your-business/choose-business-structure |
+| 6 | Choose your business name | /business-guide/launch-your-business/choose-your-business-name |
+| 7 | Register your business | /business-guide/launch-your-business/register-your-business |
+| 8 | Get federal and state tax IDs | /business-guide/launch-your-business/get-federal-state-tax-id-numbers |
+| 9 | Apply for licenses and permits | /business-guide/launch-your-business/apply-licenses-permits |
+| 10 | Open a business bank account | /business-guide/launch-your-business/open-business-bank-account |
+
+## Step Descriptions (from page text)
+
+**Step 1 — Conduct market research**
+Market research tells you if there's an opportunity to turn your idea into a successful business. It's a way to gather information about potential customers and businesses already operating in your area. Use that information to find a competitive advantage.
+
+**Step 2 — Write your business plan**
+Your business plan is the foundation of your business — a roadmap for how to structure, run, and grow your new business. Used to convince people (partners, investors) that working with you is a smart choice.
+
+**Step 3 — Fund your business**
+Your business plan will help you figure out how much money you'll need to start. If you don't have that amount on hand, you'll need to either raise or borrow capital.
+
+**Step 4 — Pick your business location**
+One of the most important decisions you'll make. Whether setting up a brick-and-mortar business or launching an online store, the choices could affect your taxes, legal requirements, and revenue.
+
+**Step 5 — Choose a business structure**
+The legal structure you choose will impact your business registration requirements, how much you pay in taxes, and your personal liability.
+
+**Step 6 — Choose your business name**
+Reflect your brand and capture your spirit. Ensure the business name isn't already being used by someone else.
+
+**Step 7 — Register your business**
+Once you've picked the perfect business name, make it legal and protect your brand. If doing business under a name different than your own, you'll need to register with the federal government, and possibly your state government.
+
+**Step 8 — Get federal and state tax IDs**
+You'll use your employer identification number (EIN) for important steps: opening a bank account, paying taxes. Some (not all) states require a state tax ID as well.
+
+**Step 9 — Apply for licenses and permits**
+Stay legally compliant. The licenses and permits needed vary by industry, state, location, and other factors.
+
+**Step 10 — Open a business bank account**
+A small business checking account helps handle legal, tax, and day-to-day issues. Requires the right registrations and paperwork already in place.
+
+## Explicit Prerequisites and Ordering Logic
+
+The SBA page numbers these 1–10, signaling a recommended sequence, but does NOT use the word "prerequisite" explicitly. Implied ordering dependencies extracted from page language:
+
+### Hard sequential dependencies (stated in text):
+- **Step 2 requires Step 1**: "Your business plan will help you figure out how much money you'll need" — plan is built from market research data.
+- **Step 3 requires Step 2**: "Your business plan will help you figure out how much money you'll need to start." The plan produces the funding target.
+- **Step 7 requires Step 5 and Step 6**: "Once you've picked the perfect business name, it's time to make it legal" — registration requires knowing both structure (step 5, which determines what entity to register) and name (step 6).
+- **Step 8 partially requires Step 7**: EIN is used "like opening a bank account" — implies EIN comes before banking. Registration paperwork feeds into EIN application.
+- **Step 10 requires Step 7 and Step 8**: "It's easy to set one up if you have the right registrations and paperwork ready" — bank account requires the registrations and EIN/tax IDs.
+- **Step 9 requires Step 7**: Licenses are applied for after the business entity is registered (you must have a legal entity to apply for most licenses). Also: location (step 4) determines which licenses are required.
+
+### Looser / advisory ordering:
+- Steps 1–3 are grouped under "plan-your-business" URL path; steps 4–10 are under "launch-your-business" — indicating a plan-first, launch-second macro sequence.
+- Step 4 (location) can happen somewhat in parallel with steps 5–6, but must precede step 9 because license requirements vary by state and locality.
+- Step 5 (business structure) should precede step 6 (naming) because some structures (e.g., LLC, corporation) have naming requirements and conventions.
+
+### Dependency graph (implied):
+
+```
+1 (market research)
+  └─► 2 (business plan)
+        └─► 3 (funding)
+
+4 (location) ───────────────────────────────────────────────────┐
+5 (structure) ──► 6 (name) ──► 7 (register) ──► 8 (tax IDs) ──► 10 (bank account)
+                                      │
+                          4 (location) ──► 9 (licenses & permits)
+                          7 (register) ──► 9
+```
+
+## URL Structure Notes
+
+The SBA organizes sub-pages into two phases:
+- `/business-guide/plan-your-business/` — Steps 1–3
+- `/business-guide/launch-your-business/` — Steps 4–10
+
+This URL taxonomy reinforces the plan → launch ordering.
+
+## Data Format
+
+All files are HTML pages (standard web pages). No CSV/JSON structured data is provided by SBA directly. The structured data extracted above was parsed from page text.
+
+## Useful for Step Dependencies
+
+- The numbered sequence is the authoritative SBA ordering.
+- The text of each step description contains language that makes sequencing rationale explicit (e.g., "once you've picked the name," "your business plan will help you figure out how much money").
+- Step 9 (licenses and permits) is the primary touchpoint with occupational licensing databases (CareerOneStop, Knee Center data).
+- The SBA page for step 9 links to the SBA's own license tool: https://www.sba.gov/business-guide/launch-your-business/apply-licenses-permits — which in turn references state and federal licensing resources.


### PR DESCRIPTION
## Summary

Adds the reference datasets used to research and validate the dependency edges in PR #4.

- NJ Navigator: task-dependencies.json (32 explicit prerequisite entries), 7 industry roadmaps, TypeScript types
- Maryland PLC catalog: 1,058 PLC types with fees, processing times, agencies (1.9MB CSV)
- SBA 10-step guide: extracted dependency graph summary
- DOL CareerOneStop: API schema and data summary (large .mdb binary gitignored)
- WVU Knee Center: dataset summary (large .xlsx binary gitignored)
- .gitignore for large binary files (.mdb, .zip, .xlsx, .docx, .html)