### PR TITLE
Replace C favicon with dataset-graph favicon

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="text-scale" content="scale" />
-		<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='6' fill='%231a4480'/><text x='16' y='23' font-size='20' font-weight='bold' fill='white' text-anchor='middle' font-family='system-ui'>C</text></svg>" />
+		<link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" shape-rendering="geometricPrecision">
+	<!-- Ink background, zero-radius: matches editorial newsprint aesthetic -->
+	<rect width="32" height="32" fill="#1C1B1A"/>
+	<!-- Connecting edges (solid = hard dependency, like FlowPathOverlay strokes) -->
+	<path d="M8 10 L22 10" stroke="#F4F3F0" stroke-width="2" stroke-linecap="round"/>
+	<path d="M22 10 L16 23" stroke="#F4F3F0" stroke-width="2" stroke-linecap="round"/>
+	<!-- Three jurisdiction nodes: federal / state / local -->
+	<circle cx="8" cy="10" r="5" fill="#2A4B7C"/>
+	<circle cx="22" cy="10" r="5" fill="#4A6D5E"/>
+	<circle cx="16" cy="23" r="5" fill="#8C5A46"/>
+</svg>


### PR DESCRIPTION
New favicon echoes the methodology hero's abstract schematic: three jurisdiction-colored nodes (federal / state / local) connected by a solid-edge line on an ink background, zero-radius to match the editorial design language. Shipped as static/favicon.svg and referenced via %sveltekit.assets%/favicon.svg so it resolves under the GitHub Pages base path.